### PR TITLE
Add ability to change the metadata of a chapter file

### DIFF
--- a/MangaIngestWithUpscaling/Components/MangaManagement/Chapters/ChapterList.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/Chapters/ChapterList.razor
@@ -9,6 +9,7 @@
 
 @inject ApplicationDbContext DbContext
 @inject IMetadataHandlingService MetadataHandler
+@inject IMangaMetadataChanger MangaMetadataChanger
 @inject ITaskQueue TaskQueue
 @inject ILogger<ChapterList> Logger
 @inject IDialogService DialogService
@@ -18,7 +19,10 @@
 <MudTable T="ChapterItem" @bind-SelectedItems="selectedChapters"
           Items="@chapterItems"
           Dense="true"
-          MultiSelection="true">
+          MultiSelection="true" 
+          CanCancelEdit="true"
+          RowEditCommit="r => OnChapterMetadataCommit((ChapterItem)r)"
+          RowEditCancel="r => OnChapterMetadataDiscard((ChapterItem)r)">
     <ToolBarContent>
         <MudStack Row>
             <MudButton StartIcon="@Icons.Material.Filled.Delete"
@@ -81,6 +85,30 @@
                            title="Delete this chapter" />
         </MudTd>
     </RowTemplate>
+    <RowEditingTemplate>
+        <MudTd DataLabel="Chapter Title"><MudInput @bind-Value="context.NewTitle"/></MudTd>
+        <MudTd DataLabel="Chapter Path">@context.Chapter.RelativePath</MudTd>
+        <MudTd DataLabel="Upscaled">
+            @context.Chapter.IsUpscaled
+            @if (!context.Chapter.IsUpscaled)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward"
+                               Color="Color.Primary" Variant="Variant.Text"
+                               OnClick="@(() => UpscaleChapter(context.Chapter))"
+                               title="Upscale this chapter." />
+            }
+            else
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.ArrowDownward"
+                               Color="Color.Secondary" Variant="Variant.Text"
+                               OnClick="@(() => DeleteUpscaledConfirm(context.Chapter))"
+                               title="Delete upscaled version of this chapter." />
+            }
+        </MudTd>
+        <MudTd DataLabel="Upscaler Profile">
+            @(context.Chapter.UpscalerProfile?.Deleted == true ? $"{context.Chapter.UpscalerProfile.Name} (old)" : context.Chapter.UpscalerProfile?.Name)
+        </MudTd>
+    </RowEditingTemplate>
     <PagerContent>
         <MudTablePager />
     </PagerContent>
@@ -111,6 +139,20 @@
         {
             await DeleteChapter(chapter);
         }
+    }
+
+    private async Task OnChapterMetadataCommit(ChapterItem chapter)
+    {
+        if (chapter.ExtractedMetadata.ChapterTitle != chapter.NewTitle)
+        {
+            await MangaMetadataChanger.ChangeChapterTitle(chapter.Chapter, chapter.NewTitle);
+            chapter.ExtractedMetadata = chapter.ExtractedMetadata with { ChapterTitle = chapter.NewTitle };
+        }
+    }
+
+    private void OnChapterMetadataDiscard(ChapterItem chapter)
+    {
+        chapter.NewTitle = chapter.ExtractedMetadata.ChapterTitle;
     }
 
     private async Task DeleteChapter(Chapter chapter)
@@ -245,7 +287,7 @@
             {
                 var extractedMetadata = MetadataHandler.GetSeriesAndTitleFromComicInfo(Path.Combine(Manga.Library.NotUpscaledLibraryPath, chapter.RelativePath));
                 chapter.UpscalerProfile = await loadProfile;
-                chapters.Add(new ChapterItem { Chapter = chapter, ExtractedMetadata = extractedMetadata });
+                chapters.Add(new ChapterItem { Chapter = chapter, ExtractedMetadata = extractedMetadata, NewTitle = extractedMetadata.ChapterTitle });
             }
             catch (Exception e)
             {
@@ -263,5 +305,6 @@
     {
         public Chapter Chapter { get; set; }
         public ExtractedMetadata ExtractedMetadata { get; set; }
+        public string NewTitle { get; set; }
     }
 }

--- a/MangaIngestWithUpscaling/Components/MangaManagement/EditManga.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/EditManga.razor
@@ -154,7 +154,7 @@
                 originalTitle = newTitle;
                 try
                 {
-                    await MetadataChanger.ChangeTitle(manga, newTitle, addOldTitleToOtherTitles);
+                    await MetadataChanger.ChangeMangaTitle(manga, newTitle, addOldTitleToOtherTitles);
                 }
                 catch (Exception e)
                 {

--- a/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
@@ -303,7 +303,7 @@
             manga.PrimaryTitle = mangaBeforeEdit.PrimaryTitle;
             try
             {
-                await MangaMetadataChanger.ChangeTitle(manga, newTitle.Trim());
+                await MangaMetadataChanger.ChangeMangaTitle(manga, newTitle.Trim());
             }
             catch (Exception e)
             {

--- a/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/RenameUpscaledChaptersSeriesTask.cs
+++ b/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/RenameUpscaledChaptersSeriesTask.cs
@@ -65,7 +65,7 @@ public class RenameUpscaledChaptersSeriesTask : BaseTask
 
         var metadataChange = services.GetRequiredService<IMangaMetadataChanger>();
 
-        metadataChange.ApplyUpscaledChapterTitle(chapter, NewTitle, origChapterPath);
+        metadataChange.ApplyMangaTitleToUpscaled(chapter, NewTitle, origChapterPath);
     }
 
     public override string TaskFriendlyName => $"Changing {ChapterFileName} title attribute to \"{NewTitle}\"";

--- a/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/UpscaleTask.cs
+++ b/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/UpscaleTask.cs
@@ -99,7 +99,7 @@ public class UpscaleTask : BaseTask
         // make sure that the new chapter is applied
         if (oldMangaTitle != chapter.Manga.PrimaryTitle)
         {
-            metadataChanger.ApplyUpscaledChapterTitle(chapter, chapter.Manga.PrimaryTitle, upscaleTargetPath);
+            metadataChanger.ApplyMangaTitleToUpscaled(chapter, chapter.Manga.PrimaryTitle, upscaleTargetPath);
         }
     }
 

--- a/MangaIngestWithUpscaling/Services/MangaManagement/MangaMerger.cs
+++ b/MangaIngestWithUpscaling/Services/MangaManagement/MangaMerger.cs
@@ -91,7 +91,7 @@ public class MangaMerger(
                         {
                             try
                             {
-                                metadataChanger.ApplyUpscaledChapterTitle(chapter, primary.PrimaryTitle!, upscaledPath);
+                                metadataChanger.ApplyMangaTitleToUpscaled(chapter, primary.PrimaryTitle!, upscaledPath);
                             }
                             catch (Exception ex)
                             {

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
@@ -19,7 +19,7 @@ public interface IMangaMetadataChanger
     /// </param>
     /// <exception cref="TitleAlreadyUsedException">Indicates that the title has already been used.</exception>
     /// <returns></returns>
-    Task ChangeTitle(Manga manga, string newTitle, bool addOldToAlternative = true);
+    Task ChangeMangaTitle(Manga manga, string newTitle, bool addOldToAlternative = true);
     /// <summary>
     /// Updates the title of a upscaled chapter file and moves it to the correct directory.
     /// </summary>

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
@@ -31,4 +31,10 @@ public interface IMangaMetadataChanger
     /// If the upscaling takes too long, then the metadata might be stale and not reflect the current state of the manga series.
     /// </remarks>
     void ApplyMangaTitleToUpscaled(Chapter chapter, string newTitle, string origChapterPath);
+    /// <summary>
+    /// Changes the title of a chapter in the ComicInfo.xml metadata file.
+    /// </summary>
+    /// <param name="chapter">The chapter whose metadata to change.</param>
+    /// <param name="newTitle">The new title to apply.</param>
+    Task ChangeChapterTitle(Chapter chapter, string newTitle);
 }

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
@@ -30,5 +30,5 @@ public interface IMangaMetadataChanger
     /// This is mainly used outside of <see cref="MangaMetadataChanger"/> to ensure that the Metadata changes are applied to the currently upscaled chapters as well.
     /// If the upscaling takes too long, then the metadata might be stale and not reflect the current state of the manga series.
     /// </remarks>
-    void ApplyUpscaledChapterTitle(Chapter chapter, string newTitle, string origChapterPath);
+    void ApplyMangaTitleToUpscaled(Chapter chapter, string newTitle, string origChapterPath);
 }

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
@@ -97,8 +97,8 @@ public class MangaMetadataChanger(
     {
         // move chapter to the correct directory with the new title
         var newChapterPath = Path.Combine(
-            libraryBasePath, 
-            PathEscaper.EscapeFileName(newTitle), 
+            libraryBasePath,
+            PathEscaper.EscapeFileName(newTitle),
             PathEscaper.EscapeFileName(chapter.FileName));
         var newRelativePath = Path.GetRelativePath(libraryBasePath, newChapterPath);
         if (File.Exists(newChapterPath))
@@ -124,4 +124,38 @@ public class MangaMetadataChanger(
         var newMetadata = metadata with { Series = newTitle };
         metadataHandling.WriteComicInfo(origChapterPath, newMetadata);
     }
+
+    /// <inheritdoc/>
+    public async Task ChangeChapterTitle(Chapter chapter, string newTitle)
+    {
+        await dbContext.Entry(chapter).Reference(c => c.Manga).LoadAsync();
+        await dbContext.Entry(chapter.Manga).Reference(m => m.Library).LoadAsync();
+
+        try
+        {
+            metadataHandling.WriteComicInfo(chapter.NotUpscaledFullPath,
+                metadataHandling.GetSeriesAndTitleFromComicInfo(chapter.NotUpscaledFullPath) with { ChapterTitle = newTitle });
+
+            if (chapter.IsUpscaled)
+            {
+                if (chapter.UpscaledFullPath == null)
+                {
+                    logger.LogWarning("Upscaled chapter file not found: {ChapterPath}", chapter.UpscaledFullPath);
+                    return;
+                }
+
+                metadataHandling.WriteComicInfo(chapter.UpscaledFullPath,
+                    metadataHandling.GetSeriesAndTitleFromComicInfo(chapter.UpscaledFullPath) with { ChapterTitle = newTitle });
+            }
+        }
+        catch (XmlException ex)
+        {
+            logger.LogWarning(ex, "Error parsing ComicInfo XML for chapter {ChapterId} ({ChapterPath})", chapter.Id, chapter.RelativePath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating metadata for chapter {ChapterId} ({ChapterPath})", chapter.Id, chapter.RelativePath);
+        }
+    }
+
 }

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
@@ -46,7 +46,7 @@ public class MangaMetadataChanger(
     }
 
     /// <inheritdoc/>
-    public async Task ChangeTitle(Manga manga, string newTitle, bool addOldToAlternative = true)
+    public async Task ChangeMangaTitle(Manga manga, string newTitle, bool addOldToAlternative = true)
     {
         manga.ChangePrimaryTitle(newTitle, addOldToAlternative);
 

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
@@ -23,7 +23,7 @@ public class MangaMetadataChanger(
     IChapterChangedNotifier chapterChangedNotifier) : IMangaMetadataChanger
 {
     /// <inheritdoc/>
-    public void ApplyUpscaledChapterTitle(Chapter chapter, string newTitle, string origChapterPath)
+    public void ApplyMangaTitleToUpscaled(Chapter chapter, string newTitle, string origChapterPath)
     {
         if (!File.Exists(origChapterPath))
         {
@@ -77,7 +77,7 @@ public class MangaMetadataChanger(
 
                 if (chapter.IsUpscaled)
                 {
-                    ApplyUpscaledChapterTitle(chapter, newTitle, Path.Combine(manga.Library.UpscaledLibraryPath!, oldRelativePath));
+                    ApplyMangaTitleToUpscaled(chapter, newTitle, Path.Combine(manga.Library.UpscaledLibraryPath!, oldRelativePath));
                 }
             }
             catch (XmlException ex)


### PR DESCRIPTION
The ComicInfo.xml-file can be used to encode the title of a chapter. This field will now be editable as well.