### PR TITLE
Offer to merge mangas if the new name is same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,6 @@ MangaIngestWithUpscaling/data.db*
 
 # IDEA
 .idea/
+
+# test data
+test_data/

--- a/MangaIngestWithUpscaling/Components/MangaManagement/EditManga.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/EditManga.razor
@@ -16,7 +16,9 @@
         <MudCard Elevation="2">
             <MudCardHeader>
                 <MudStack Row="true" AlignItems="AlignItems.Center">
-                    <a href="mangas"><MudIconButton Icon="@Icons.Material.Filled.ArrowBack" /></a>
+                    <a href="mangas">
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowBack"/>
+                    </a>
                     <MudText Typo="Typo.h4">Edit "@manga.PrimaryTitle"</MudText>
                 </MudStack>
             </MudCardHeader>
@@ -28,14 +30,14 @@
                     <MudItem xs="12">
                         <MudStack Spacing="0">
                             <MudTextField Label="Primary Title"
-                            @bind-Value="manga.PrimaryTitle"
-                            Immediate="true"
-                            Variant="Variant.Outlined"
-                            HelperText="The primary title you want this manga to go by."
-                            Required />
+                                          @bind-Value="manga.PrimaryTitle"
+                                          Immediate="true"
+                                          Variant="Variant.Outlined"
+                                          HelperText="The primary title you want this manga to go by."
+                                          Required/>
                             <MudCheckBox T="bool" Label="Add old title to other titles automatically when changed."
-                            @bind-Value="addOldTitleToOtherTitles"
-                            Size="Size.Small" />
+                                         @bind-Value="addOldTitleToOtherTitles"
+                                         Size="Size.Small"/>
                         </MudStack>
                     </MudItem>
                     <MudItem xs="12">
@@ -48,26 +50,26 @@
                             <MudStack>
                                 <MudStack Row="true" Spacing="1">
                                     <MudTextField Label="New Title" @bind-Value="newTitle"
-                                    Immediate="true"
-                                    Class="flex-grow-1"
-                                    @ref="newTitleField" />
+                                                  Immediate="true"
+                                                  Class="flex-grow-1"
+                                                  @ref="newTitleField"/>
                                     <MudIconButton Icon="@Icons.Material.Filled.AddCircle"
-                                    Size="Size.Medium" Class="flex-shrink-0"
-                                    Disabled="string.IsNullOrWhiteSpace(newTitle)"
-                                    OnClick="_ => AddAlternativeTitle()" Color="Color.Success" />
+                                                   Size="Size.Medium" Class="flex-shrink-0"
+                                                   Disabled="string.IsNullOrWhiteSpace(newTitle)"
+                                                   OnClick="_ => AddAlternativeTitle()" Color="Color.Success"/>
                                 </MudStack>
                                 <MudList T="MangaAlternativeTitle"
-                                @ref="titlesList" @bind-SelectedValues="selectedTitles">
+                                         @ref="titlesList" @bind-SelectedValues="selectedTitles">
                                     @foreach (var title in manga.OtherTitles.OrderBy(t => t.Title))
                                     {
                                         <MudListItem Value="@title">
                                             <MudStack Row="true" AlignItems="AlignItems.Center">
                                                 <MudText>@title.Title</MudText>
-                                                <MudSpacer />
+                                                <MudSpacer/>
                                                 <MudIconButton Icon="@Icons.Material.Filled.RemoveCircle"
-                                                Color="Color.Error"
-                                                Size="Size.Small"
-                                                OnClick="() => manga.OtherTitles.Remove(title)" />
+                                                               Color="Color.Error"
+                                                               Size="Size.Small"
+                                                               OnClick="() => manga.OtherTitles.Remove(title)"/>
                                             </MudStack>
                                         </MudListItem>
                                     }
@@ -78,7 +80,9 @@
                 </MudGrid>
             </MudCardContent>
             <MudCardActions>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Save" Disabled="@(!isTouched || !isValid)">Save</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Save"
+                           Disabled="@(!isTouched || !isValid)">Save
+                </MudButton>
             </MudCardActions>
         </MudCard>
     </MudForm>
@@ -96,7 +100,7 @@
             </MudStack>
         </MudCardHeader>
         <MudCardContent>
-            <ChapterList Manga="@manga" />
+            <ChapterList Manga="@manga"/>
         </MudCardContent>
     </MudCard>
 </MudStack>
@@ -129,6 +133,7 @@
         {
             NavigationManager.NavigateTo("/mangas");
         }
+
         originalTitle = manga.PrimaryTitle;
     }
 
@@ -136,11 +141,11 @@
     {
         if (!string.IsNullOrEmpty(newTitle))
             manga.OtherTitles.Add(new MangaAlternativeTitle
-                {
-                    Title = newTitle,
-                    MangaId = manga.Id,
-                    Manga = manga
-                });
+            {
+                Title = newTitle,
+                MangaId = manga.Id,
+                Manga = manga
+            });
     }
 
     private async Task Save()
@@ -151,10 +156,14 @@
             {
                 var newTitle = manga.PrimaryTitle.Trim();
                 manga.PrimaryTitle = originalTitle;
-                originalTitle = newTitle;
                 try
                 {
-                    await MetadataChanger.ChangeMangaTitle(manga, newTitle, addOldTitleToOtherTitles);
+                    var renameResult = await MetadataChanger.ChangeMangaTitle(manga, newTitle, addOldTitleToOtherTitles);
+                    if (renameResult == RenameResult.Cancelled)
+                    {
+                        manga.PrimaryTitle = newTitle;
+                        return;
+                    }
                 }
                 catch (Exception e)
                 {
@@ -175,4 +184,5 @@
             }
         }
     }
+
 }

--- a/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
@@ -308,6 +308,7 @@
                 if (renameResult is not RenameResult.Ok)
                 {
                     await table.ReloadServerData();
+                    return;
                 }
             }
             catch (Exception e)

--- a/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
@@ -304,7 +304,11 @@
             manga.PrimaryTitle = mangaBeforeEdit.PrimaryTitle;
             try
             {
-                await MangaMetadataChanger.ChangeMangaTitle(manga, newTitle.Trim());
+                var renameResult = await MangaMetadataChanger.ChangeMangaTitle(manga, newTitle.Trim());
+                if (renameResult is RenameResult.Merged)
+                {
+                    await table.ReloadServerData();
+                }
             }
             catch (Exception e)
             {

--- a/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/Mangas.razor
@@ -305,7 +305,7 @@
             try
             {
                 var renameResult = await MangaMetadataChanger.ChangeMangaTitle(manga, newTitle.Trim());
-                if (renameResult is RenameResult.Merged)
+                if (renameResult is not RenameResult.Ok)
                 {
                     await table.ReloadServerData();
                 }

--- a/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/BaseTask.cs
+++ b/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/BaseTask.cs
@@ -13,6 +13,7 @@ namespace MangaIngestWithUpscaling.Services.BackqroundTaskQueue.Tasks;
 [JsonDerivedType(typeof(ScanIngestTask), nameof(ScanIngestTask))]
 [JsonDerivedType(typeof(RenameUpscaledChaptersSeriesTask), nameof(RenameUpscaledChaptersSeriesTask))]
 [JsonDerivedType(typeof(LibraryIntegrityCheckTask), nameof(LibraryIntegrityCheckTask))]
+[JsonDerivedType(typeof(MergeMangaTask), nameof(MergeMangaTask))]
 public class BaseTask
 {
     public virtual Task ProcessAsync(IServiceProvider services, CancellationToken cancellationToken)

--- a/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/MergeMangaTask.cs
+++ b/MangaIngestWithUpscaling/Services/BackqroundTaskQueue/Tasks/MergeMangaTask.cs
@@ -1,0 +1,60 @@
+﻿using MangaIngestWithUpscaling.Data;
+using MangaIngestWithUpscaling.Data.LibraryManagement;
+using MangaIngestWithUpscaling.Services.MangaManagement;
+using Microsoft.EntityFrameworkCore;
+
+namespace MangaIngestWithUpscaling.Services.BackqroundTaskQueue.Tasks;
+
+public class MergeMangaTask : BaseTask
+{
+    public override string TaskFriendlyName => MergeMessage;
+    
+
+    public int IntoMangaId { get; set; }
+    
+    public List<int> ToMerge { get; set; }
+
+    public string MergeMessage { get; set; }
+    
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    [Obsolete("Is your name JsonSerializer? No, I didn't think so.", true)]
+    public MergeMangaTask() {}
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    public MergeMangaTask(Manga into, List<Manga> toMerge)
+    {
+        IntoMangaId = into.Id;
+        ToMerge = toMerge.Select(m => m.Id).ToList();
+        MergeMessage = $"Merging {toMerge.Count} Mangas into {into.PrimaryTitle}";
+    }
+
+    public override async Task ProcessAsync(IServiceProvider services, CancellationToken cancellationToken)
+    {
+        var merger = services.GetRequiredService<IMangaMerger>();
+        var dbContext = services.GetRequiredService<ApplicationDbContext>();
+        var logger = services.GetRequiredService<ILogger<MergeMangaTask>>();
+        var into = await dbContext.MangaSeries.FindAsync(IntoMangaId, cancellationToken);
+        var toMerge = await dbContext.MangaSeries.Where(m => ToMerge.Contains(m.Id)).ToListAsync(cancellationToken);
+
+        if (into == null)
+        {
+            logger.LogCritical("Could not find manga to merge into with the id of {IntoMangaId}", IntoMangaId);
+            return;
+        }
+
+        if (toMerge.Count == 0)
+        {
+            logger.LogCritical("Could not find any of the mangas to merge into {IntoMangaId}: {ToMerge}", IntoMangaId, ToMerge);
+            return;
+        }
+
+        if (toMerge.Count != ToMerge.Count)
+        {
+            logger.LogWarning("Could not find some of the mangas to merge into {IntoMangaId}: {ToMergeMissing}", 
+                IntoMangaId, ToMerge.Where(t => !toMerge.Select(m => m.Id).Contains(t)));
+        }
+
+        await merger.MergeAsync(into, toMerge, cancellationToken);
+    }
+
+    public override int RetryFor { get; set; } = 1;
+}

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
@@ -42,5 +42,5 @@ public interface IMangaMetadataChanger
 
 public enum RenameResult
 {
-    Ok, Merged 
+    Ok, Merged, Cancelled
 }

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/IMangaMetadataChanger.cs
@@ -17,9 +17,10 @@ public interface IMangaMetadataChanger
     /// If <c>true</c>, this will add the old title to the list of other titles.
     /// This is useful to recognize ingested chapters of the same series with different titles (i.e english and japanese).
     /// </param>
+    /// <param name="cancellationToken">The token to cancel the operation.</param>
     /// <exception cref="TitleAlreadyUsedException">Indicates that the title has already been used.</exception>
     /// <returns></returns>
-    Task ChangeMangaTitle(Manga manga, string newTitle, bool addOldToAlternative = true);
+    Task<RenameResult> ChangeMangaTitle(Manga manga, string newTitle, bool addOldToAlternative = true, CancellationToken cancellationToken = default);
     /// <summary>
     /// Updates the title of a upscaled chapter file and moves it to the correct directory.
     /// </summary>
@@ -37,4 +38,9 @@ public interface IMangaMetadataChanger
     /// <param name="chapter">The chapter whose metadata to change.</param>
     /// <param name="newTitle">The new title to apply.</param>
     Task ChangeChapterTitle(Chapter chapter, string newTitle);
+}
+
+public enum RenameResult
+{
+    Ok, Merged 
 }

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
@@ -55,7 +55,8 @@ public class MangaMetadataChanger(
         CancellationToken cancellationToken = default)
     {
         var possibleCurrent = await dbContext.MangaSeries.FirstOrDefaultAsync(m =>
-            m.PrimaryTitle == newTitle || m.OtherTitles.Any(t => t.Title == newTitle),
+                m.Id != manga.Id && // prevent accidental self-merge
+            (m.PrimaryTitle == newTitle || m.OtherTitles.Any(t => t.Title == newTitle)),
             cancellationToken: cancellationToken);
 
         if (possibleCurrent != null)

--- a/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
+++ b/MangaIngestWithUpscaling/Services/MetadataHandling/MangaMetadataChanger.cs
@@ -55,7 +55,8 @@ public class MangaMetadataChanger(
         CancellationToken cancellationToken = default)
     {
         var possibleCurrent = await dbContext.MangaSeries.FirstOrDefaultAsync(m =>
-            m.PrimaryTitle == newTitle || m.OtherTitles.Any(t => t.Title == newTitle));
+            m.PrimaryTitle == newTitle || m.OtherTitles.Any(t => t.Title == newTitle),
+            cancellationToken: cancellationToken);
 
         if (possibleCurrent != null)
         {


### PR DESCRIPTION
When renaming a manga, it can be the case that the new title already has an existing title. After this change, the user is prompted to either merge into the existing entry or cancel the process.