### PR TITLE
Save upscaler configuration in the generated files

### DIFF
--- a/MangaIngestWithUpscaling.Shared/Data/LibraryManagement/UpscalerProfile.cs
+++ b/MangaIngestWithUpscaling.Shared/Data/LibraryManagement/UpscalerProfile.cs
@@ -8,16 +8,26 @@ namespace MangaIngestWithUpscaling.Shared.Data.LibraryManagement;
 public class UpscalerProfile
 {
     public int Id { get; set; }
-    public required string Name { get; set; }             // An identifier for this specific config
-    public UpscalerMethod UpscalerMethod { get; set; } = UpscalerMethod.MangaJaNai;   // e.g. "mangajanai"
-    public required ScaleFactor ScalingFactor { get; set; }    // e.g. "1x", "2x"
+    public required string Name { get; set; } // An identifier for this specific config
+    public UpscalerMethod UpscalerMethod { get; set; } = UpscalerMethod.MangaJaNai; // e.g. "mangajanai"
+    public required ScaleFactor ScalingFactor { get; set; } // e.g. "1x", "2x"
     public required CompressionFormat CompressionFormat { get; set; } // e.g. "avid", "png", "webp"
-    [Range(1, 100)]
-    public required int Quality { get; set; }            // e.g. 80, 90
+
+    [Range(1, 100)] public required int Quality { get; set; } // e.g. 80, 90
+
     /// <summary>
     /// Whether this profile is deleted. Deleted profiles cannot be selected but might still be referenced by chapters.
     /// </summary>
     public bool Deleted { get; set; } = false;
+}
+
+public record UpscalerProfileJsonDto
+{
+    public required string Name { get; set; }
+    public required UpscalerMethod UpscalerMethod { get; set; }
+    public required int ScalingFactor { get; set; }
+    public required CompressionFormat CompressionFormat { get; set; }
+    public required int Quality { get; set; }
 }
 
 public enum UpscalerMethod
@@ -30,14 +40,10 @@ public enum UpscalerMethod
 /// </summary>
 public enum ScaleFactor
 {
-    [Display(Name = "1x")]
-    OneX = 1,
-    [Display(Name = "2x")]
-    TwoX = 2,
-    [Display(Name = "3x")]
-    ThreeX = 3,
-    [Display(Name = "4x")]
-    FourX = 4
+    [Display(Name = "1x")] OneX = 1,
+    [Display(Name = "2x")] TwoX = 2,
+    [Display(Name = "3x")] ThreeX = 3,
+    [Display(Name = "4x")] FourX = 4
 }
 
 /// <summary>
@@ -45,12 +51,8 @@ public enum ScaleFactor
 /// </summary>
 public enum CompressionFormat
 {
-    [Display(Name = "AVIF")]
-    Avif,
-    [Display(Name = "PNG")]
-    Png,
-    [Display(Name = "WebP")]
-    Webp,
-    [Display(Name = "JPEG")]
-    Jpg
+    [Display(Name = "AVIF")] Avif,
+    [Display(Name = "PNG")] Png,
+    [Display(Name = "WebP")] Webp,
+    [Display(Name = "JPEG")] Jpg
 }

--- a/MangaIngestWithUpscaling.Shared/Services/Upscaling/IUpscalerJsonHandlingService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/Upscaling/IUpscalerJsonHandlingService.cs
@@ -1,0 +1,9 @@
+using MangaIngestWithUpscaling.Shared.Data.LibraryManagement;
+
+namespace MangaIngestWithUpscaling.Shared.Services.Upscaling;
+
+public interface IUpscalerJsonHandlingService
+{
+    Task<UpscalerProfileJsonDto?> ReadUpscalerJsonAsync(string cbzFilePath, CancellationToken cancellationToken);
+    Task WriteUpscalerJsonAsync(string cbzFilePath, UpscalerProfile profile, CancellationToken cancellationToken);
+}

--- a/MangaIngestWithUpscaling.Shared/Services/Upscaling/MangaJaNaiUpscaler.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/Upscaling/MangaJaNaiUpscaler.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.IO.Compression;
 using System.Security.Cryptography;
-using System.Text.Json;
 
 namespace MangaIngestWithUpscaling.Shared.Services.Upscaling;
 
@@ -17,7 +16,8 @@ public class MangaJaNaiUpscaler(
     ILogger<MangaJaNaiUpscaler> logger,
     IOptions<UpscalerConfig> sharedConfig,
     IFileSystem fileSystem,
-    IMetadataHandlingService metadataHandling) : IUpscaler
+    IMetadataHandlingService metadataHandling,
+    IUpscalerJsonHandlingService upscalerJsonHandlingService) : IUpscaler
 {
     private readonly (string, string)[] zipsToDownload =
     [
@@ -135,30 +135,7 @@ public class MangaJaNaiUpscaler(
 
             logger.LogDebug("Upscaling Output {inputPath}: {output}", inputPath, output);
 
-            var upscalerJson = new UpscalerProfileJsonDto
-            {
-                Name = profile.Name,
-                UpscalerMethod = profile.UpscalerMethod,
-                ScalingFactor = (int)profile.ScalingFactor,
-                CompressionFormat = profile.CompressionFormat,
-                Quality = profile.Quality
-            };
-
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            string jsonString = JsonSerializer.Serialize(upscalerJson, options);
-
-            using (ZipArchive archive = ZipFile.Open(outputPath, ZipArchiveMode.Update))
-            {
-                ZipArchiveEntry? existingEntry = archive.GetEntry("upscaler.json");
-                existingEntry?.Delete();
-
-                ZipArchiveEntry entry = archive.CreateEntry("upscaler.json");
-                await using (Stream stream = entry.Open())
-                await using (var writer = new StreamWriter(stream))
-                {
-                    await writer.WriteAsync(jsonString);
-                }
-            }
+            await upscalerJsonHandlingService.WriteUpscalerJsonAsync(outputPath, profile, cancellationToken);
 
             logger.LogInformation("Upscaling {inputPath} to {outputPath} with {profile.Name} completed", inputPath,
                 outputPath, profile.Name);

--- a/MangaIngestWithUpscaling.Shared/Services/Upscaling/UpscalerJsonHandlingService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/Upscaling/UpscalerJsonHandlingService.cs
@@ -1,0 +1,67 @@
+using MangaIngestWithUpscaling.Shared.Data.LibraryManagement;
+using Microsoft.Extensions.Logging;
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace MangaIngestWithUpscaling.Shared.Services.Upscaling;
+
+[RegisterScoped]
+public class UpscalerJsonHandlingService(ILogger<UpscalerJsonHandlingService> logger) : IUpscalerJsonHandlingService
+{
+    public async Task<UpscalerProfileJsonDto?> ReadUpscalerJsonAsync(string cbzFilePath,
+        CancellationToken cancellationToken)
+    {
+        if (!cbzFilePath.EndsWith(".cbz", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        try
+        {
+            using ZipArchive archive = ZipFile.OpenRead(cbzFilePath);
+            ZipArchiveEntry? upscalerJsonEntry = archive.GetEntry("upscaler.json");
+            if (upscalerJsonEntry != null)
+            {
+                await using Stream stream = upscalerJsonEntry.Open();
+                var upscalerProfileDto = await JsonSerializer.DeserializeAsync<UpscalerProfileJsonDto>(stream,
+                    cancellationToken: cancellationToken);
+                return upscalerProfileDto;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking for upscaler.json in {Path}", cbzFilePath);
+        }
+
+        return null;
+    }
+
+    public async Task WriteUpscalerJsonAsync(string cbzFilePath, UpscalerProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var upscalerJson = new UpscalerProfileJsonDto
+        {
+            Name = profile.Name,
+            UpscalerMethod = profile.UpscalerMethod,
+            ScalingFactor = (int)profile.ScalingFactor,
+            CompressionFormat = profile.CompressionFormat,
+            Quality = profile.Quality
+        };
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        string jsonString = JsonSerializer.Serialize(upscalerJson, options);
+
+        using (ZipArchive archive = ZipFile.Open(cbzFilePath, ZipArchiveMode.Update))
+        {
+            ZipArchiveEntry? existingEntry = archive.GetEntry("upscaler.json");
+            existingEntry?.Delete();
+
+            ZipArchiveEntry entry = archive.CreateEntry("upscaler.json");
+            await using (Stream stream = entry.Open())
+            await using (var writer = new StreamWriter(stream))
+            {
+                await writer.WriteAsync(jsonString);
+            }
+        }
+    }
+}

--- a/MangaIngestWithUpscaling.Shared/Services/Upscaling/UpscalerJsonHandlingService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/Upscaling/UpscalerJsonHandlingService.cs
@@ -23,8 +23,9 @@ public class UpscalerJsonHandlingService(ILogger<UpscalerJsonHandlingService> lo
             if (upscalerJsonEntry != null)
             {
                 await using Stream stream = upscalerJsonEntry.Open();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
                 var upscalerProfileDto = await JsonSerializer.DeserializeAsync<UpscalerProfileJsonDto>(stream,
-                    cancellationToken: cancellationToken);
+                    options, cancellationToken: cancellationToken);
                 return upscalerProfileDto;
             }
         }

--- a/MangaIngestWithUpscaling.Shared/Services/Upscaling/UpscalerJsonHandlingService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/Upscaling/UpscalerJsonHandlingService.cs
@@ -48,7 +48,11 @@ public class UpscalerJsonHandlingService(ILogger<UpscalerJsonHandlingService> lo
             Quality = profile.Quality
         };
 
-        var options = new JsonSerializerOptions { WriteIndented = true };
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
         string jsonString = JsonSerializer.Serialize(upscalerJson, options);
 
         using (ZipArchive archive = ZipFile.Open(cbzFilePath, ZipArchiveMode.Update))

--- a/MangaIngestWithUpscaling/Components/MangaManagement/Chapters/ChapterList.razor
+++ b/MangaIngestWithUpscaling/Components/MangaManagement/Chapters/ChapterList.razor
@@ -70,14 +70,14 @@
                 <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward"
                                Color="Color.Primary" Variant="Variant.Text"
                                OnClick="@(() => UpscaleChapter(context.Chapter))"
-                               title="Upscale this chapter." />
+                               title="Upscale this chapter."/>
             }
             else
             {
                 <MudIconButton Icon="@Icons.Material.Filled.ArrowDownward"
                                Color="Color.Secondary" Variant="Variant.Text"
                                OnClick="@(() => DeleteUpscaledConfirm(context.Chapter))"
-                               title="Delete upscaled version of this chapter." />
+                               title="Delete upscaled version of this chapter."/>
             }
         </MudTd>
         <MudTd DataLabel="Upscaler Profile">
@@ -87,12 +87,17 @@
             <MudIconButton Icon="@Icons.Material.Filled.Delete"
                            Color="Color.Error" Variant="Variant.Text"
                            OnClick="@(() => DeleteChapterConfirm(context.Chapter))"
-                           title="Delete this chapter" />
+                           title="Delete this chapter"/>
         </MudTd>
     </RowTemplate>
     <RowEditingTemplate>
-        <MudTd DataLabel="Chapter Title"><MudInput @bind-Value="context.NewTitle" /></MudTd>
-        <MudTd DataLabel="Chapter Path"><MudInput @bind-Value="context.NewFileName" Label="Filename" HelperText="Filename" />.cbz</MudTd>
+        <MudTd DataLabel="Chapter Title">
+            <MudInput @bind-Value="context.NewTitle"/>
+        </MudTd>
+        <MudTd DataLabel="Chapter Path">
+            <MudInput @bind-Value="context.NewFileName" Label="Filename" HelperText="Filename"/>
+            .cbz
+        </MudTd>
         <MudTd DataLabel="Upscaled">
             @context.Chapter.IsUpscaled
             @if (!context.Chapter.IsUpscaled)
@@ -100,14 +105,14 @@
                 <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward"
                                Color="Color.Primary" Variant="Variant.Text"
                                OnClick="@(() => UpscaleChapter(context.Chapter))"
-                               title="Upscale this chapter." />
+                               title="Upscale this chapter."/>
             }
             else
             {
                 <MudIconButton Icon="@Icons.Material.Filled.ArrowDownward"
                                Color="Color.Secondary" Variant="Variant.Text"
                                OnClick="@(() => DeleteUpscaledConfirm(context.Chapter))"
-                               title="Delete upscaled version of this chapter." />
+                               title="Delete upscaled version of this chapter."/>
             }
         </MudTd>
         <MudTd DataLabel="Upscaler Profile">
@@ -115,7 +120,7 @@
         </MudTd>
     </RowEditingTemplate>
     <PagerContent>
-        <MudTablePager />
+        <MudTablePager/>
     </PagerContent>
 </MudTable>
 
@@ -236,6 +241,7 @@
         {
             return;
         }
+
         if (!DbContext.Entry(Manga.Library).Reference(l => l.UpscalerProfile).IsLoaded)
         {
             await DbContext.Entry(Manga.Library).Reference(l => l.UpscalerProfile).LoadAsync();
@@ -355,6 +361,7 @@
                 }
             }
         }
+
         if (success)
         {
             chapter.RelativePath = targetRelativePath;
@@ -394,6 +401,7 @@
                 }
             }
         }
+
         return success;
     }
 
@@ -403,6 +411,7 @@
         {
             await DbContext.Entry(Manga).Collection(m => m.Chapters).LoadAsync();
         }
+
         if (!DbContext.Entry(Manga).Reference(m => m.Library).IsLoaded)
         {
             await DbContext.Entry(Manga).Reference(m => m.Library).LoadAsync();
@@ -447,11 +456,13 @@
         foreach (var chapter in Manga.Chapters.ToList()) // ToList() を追加して、コレクションの変更を許可します
         {
             Task<UpscalerProfile?> loadProfile = Task.FromResult<UpscalerProfile?>(null);
-            if (chapter.UpscalerProfileId.HasValue && !DbContext.Entry(chapter).Reference(c => c.UpscalerProfile).IsLoaded)
+            if (chapter.UpscalerProfileId is not null && !DbContext.Entry(chapter).Reference(c => c.UpscalerProfile).IsLoaded)
             {
                 // The following is used to ignore soft deleted profiles
-                loadProfile = DbContext.UpscalerProfiles.IgnoreQueryFilters().FirstOrDefaultAsync(p => p.Id == chapter.UpscalerProfileId);
+                loadProfile = DbContext.UpscalerProfiles.IgnoreQueryFilters()
+                    .FirstOrDefaultAsync(p => p.Id == chapter.UpscalerProfileId);
             }
+
             try
             {
                 if (Manga.Library?.NotUpscaledLibraryPath == null)
@@ -466,15 +477,16 @@
                     loadingFailed = true;
                     continue;
                 }
+
                 var extractedMetadata = MetadataHandler.GetSeriesAndTitleFromComicInfo(Path.Combine(Manga.Library.NotUpscaledLibraryPath, chapter.RelativePath));
                 chapter.UpscalerProfile = await loadProfile;
                 chapters.Add(new ChapterItem
-                    {
-                        Chapter = chapter,
-                        ExtractedMetadata = extractedMetadata,
-                        NewTitle = extractedMetadata?.ChapterTitle ?? string.Empty,
-                        NewFileName = Path.GetFileNameWithoutExtension(chapter.FileName)
-                    });
+                {
+                    Chapter = chapter,
+                    ExtractedMetadata = extractedMetadata,
+                    NewTitle = extractedMetadata?.ChapterTitle ?? string.Empty,
+                    NewFileName = Path.GetFileNameWithoutExtension(chapter.FileName)
+                });
             }
             catch (Exception e)
             {
@@ -495,4 +507,5 @@
         public required string NewTitle { get; set; }
         public required string NewFileName { get; set; }
     }
+
 }

--- a/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
+++ b/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
@@ -21,7 +21,7 @@ namespace MangaIngestWithUpscaling.Services.ChapterManagement;
 public partial class IngestProcessor(
     ApplicationDbContext dbContext,
     IChapterInIngestRecognitionService chapterRecognitionService,
-    ILibraryRenamingService renamingService, // add renaming service
+    ILibraryRenamingService renamingService,
     ICbzConverter cbzConverter,
     ILogger<IngestProcessor> logger,
     ITaskQueue taskQueue,

--- a/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
+++ b/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
@@ -64,12 +64,12 @@ public partial class IngestProcessor(
             bool isUpscaled = IsUpscaledChapter().IsMatch(originalChapter.RelativePath);
             UpscalerProfileJsonDto? upscalerProfileDto = null;
 
-            if (!isUpscaled)
+            string fullPath = Path.Combine(library.IngestPath, originalChapter.RelativePath);
+            upscalerProfileDto =
+                await upscalerJsonHandlingService.ReadUpscalerJsonAsync(fullPath, cancellationToken);
+            if (upscalerProfileDto != null)
             {
-                string fullPath = Path.Combine(library.IngestPath, originalChapter.RelativePath);
-                upscalerProfileDto =
-                    await upscalerJsonHandlingService.ReadUpscalerJsonAsync(fullPath, cancellationToken);
-                isUpscaled = upscalerProfileDto != null;
+                isUpscaled = true;
             }
 
             processedChapters.Add(new ProcessedChapterInfo(originalChapter, renamedChapter, isUpscaled,

--- a/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
+++ b/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
@@ -80,6 +80,9 @@ public partial class IngestProcessor(
         var chaptersBySeries = processedChapters
             .GroupBy(pci => pci.Renamed.Metadata.Series)
             .ToDictionary(g => g.Key,
+                // Sort chapters so that non-upscaled chapters come before upscaled ones
+                // By processing the non-upscaled chapters first, we ensure that if we also encounter a matching upscaled
+                // chapter, we can associate it with the correct non-upscaled chapter.
                 g => g.OrderBy(pci => pci.IsUpscaled).ToList());
 
         List<(Chapter, UpscalerProfile)> chaptersToUpscale = new();

--- a/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
+++ b/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
@@ -411,6 +411,7 @@ public partial class IngestProcessor(
         nonUpscaledChapter.IsUpscaled = true;
         if (profileToUse != null)
         {
+            nonUpscaledChapter.UpscalerProfileId = profileToUse.Id;
             nonUpscaledChapter.UpscalerProfile = profileToUse;
         }
 

--- a/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
+++ b/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
@@ -327,8 +327,7 @@ public partial class IngestProcessor(
                         p.UpscalerMethod == upscalerProfileDto.UpscalerMethod &&
                         p.ScalingFactor == scaleFactor &&
                         p.CompressionFormat == upscalerProfileDto.CompressionFormat &&
-                        p.Quality == upscalerProfileDto.Quality &&
-                        !p.Deleted,
+                        p.Quality == upscalerProfileDto.Quality,
                     cancellationToken
                 );
 

--- a/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
+++ b/MangaIngestWithUpscaling/Services/ChapterManagement/IngestProcessor.cs
@@ -323,7 +323,7 @@ public partial class IngestProcessor(
             {
                 var scaleFactor = (ScaleFactor)upscalerProfileDto.ScalingFactor;
                 profileToUse = await dbContext.UpscalerProfiles.FirstOrDefaultAsync(p =>
-                        p.Name == upscalerProfileDto.Name &&
+                        p.Name.ToLower() == upscalerProfileDto.Name.ToLower() &&
                         p.UpscalerMethod == upscalerProfileDto.UpscalerMethod &&
                         p.ScalingFactor == scaleFactor &&
                         p.CompressionFormat == upscalerProfileDto.CompressionFormat &&

--- a/docs/upscaler.schema.json
+++ b/docs/upscaler.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Upscaler Profile",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "An identifier for this specific config."
+    },
+    "upscalerMethod": {
+      "type": "string",
+      "enum": ["MangaJaNai"],
+      "description": "The upscaler method used."
+    },
+    "scalingFactor": {
+      "type": "integer",
+      "enum": [1, 2, 3, 4],
+      "description": "The scaling factor used for upscaling."
+    },
+    "compressionFormat": {
+      "type": "string",
+      "enum": ["Avif", "Png", "Webp", "Jpg"],
+      "description": "The compression format for the output."
+    },
+    "quality": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "The quality of the compression."
+    }
+  },
+  "required": [
+    "name",
+    "upscalerMethod",
+    "scalingFactor",
+    "compressionFormat",
+    "quality"
+  ]
+}
+


### PR DESCRIPTION
Saves the configuration in the generated .cbz-files in a new entry called `upscaler.json`. It will also try to restore/reuse/recreate such profiles when importing already-upscaled chapters.

Fixes #15 