### PR TITLE
Limit size to prevent timeout

### DIFF
--- a/MangaIngestWithUpscaling.RemoteWorker/appsettings.json
+++ b/MangaIngestWithUpscaling.RemoteWorker/appsettings.json
@@ -16,5 +16,12 @@
   "WorkerConfig": {
     "ApiKey": "<PUT YOUR API KEY HERE>",
     "ApiUrl": "https://your.mangaingest.tld"
-  }
+  },
+//  "Upscaler": {
+//    "UseFp16": true,
+//    "UseCPU": false,
+//    "SelectedDeviceIndex": 0,
+//    "PreferredGpuBackend": "Auto",
+//    "MaxDimensionBeforeUpscaling": null
+//  }
 }

--- a/MangaIngestWithUpscaling.Shared/Configuration/UpscalerConfig.cs
+++ b/MangaIngestWithUpscaling.Shared/Configuration/UpscalerConfig.cs
@@ -47,4 +47,11 @@ public record UpscalerConfig
     );
 
     public TimeSpan UpscaleTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    ///     Maximum dimension (width or height) for images before upscaling. 
+    ///     Images larger than this will be resized to fit within this boundary while maintaining aspect ratio.
+    ///     Set to null or 0 to disable this feature.
+    /// </summary>
+    public int? MaxDimensionBeforeUpscaling { get; set; } = null;
 }

--- a/MangaIngestWithUpscaling.Shared/MangaIngestWithUpscaling.Shared.csproj
+++ b/MangaIngestWithUpscaling.Shared/MangaIngestWithUpscaling.Shared.csproj
@@ -16,6 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.8" />
 		<PackageReference Include="Silk.NET.OpenGL" Version="2.22.0" />
 		<PackageReference Include="Silk.NET.Windowing" Version="2.22.0" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
 	</ItemGroup>
 
 </Project>

--- a/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/IImageResizeService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/IImageResizeService.cs
@@ -1,0 +1,22 @@
+namespace MangaIngestWithUpscaling.Shared.Services.ImageProcessing;
+
+/// <summary>
+/// Service for resizing images while maintaining aspect ratio
+/// </summary>
+public interface IImageResizeService
+{
+    /// <summary>
+    /// Creates a temporary resized CBZ file where all images are resized to fit within the specified maximum dimension
+    /// </summary>
+    /// <param name="inputCbzPath">Path to the input CBZ file</param>
+    /// <param name="maxDimension">Maximum width or height dimension</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Path to the temporary resized CBZ file</returns>
+    Task<string> CreateResizedTempCbzAsync(string inputCbzPath, int maxDimension, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Cleans up temporary files created by CreateResizedTempCbzAsync
+    /// </summary>
+    /// <param name="tempFilePath">Path to the temporary file to delete</param>
+    void CleanupTempFile(string tempFilePath);
+}

--- a/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/IImageResizeService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/IImageResizeService.cs
@@ -11,8 +11,8 @@ public interface IImageResizeService
     /// <param name="inputCbzPath">Path to the input CBZ file</param>
     /// <param name="maxDimension">Maximum width or height dimension</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Path to the temporary resized CBZ file</returns>
-    Task<string> CreateResizedTempCbzAsync(string inputCbzPath, int maxDimension, CancellationToken cancellationToken);
+    /// <returns>A disposable wrapper that automatically cleans up the temporary file when disposed</returns>
+    Task<TempResizedCbz> CreateResizedTempCbzAsync(string inputCbzPath, int maxDimension, CancellationToken cancellationToken);
     
     /// <summary>
     /// Cleans up temporary files created by CreateResizedTempCbzAsync

--- a/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/ImageResizeService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/ImageResizeService.cs
@@ -23,7 +23,7 @@ public class ImageResizeService : IImageResizeService
         _fileSystem = fileSystem;
     }
 
-    public async Task<string> CreateResizedTempCbzAsync(string inputCbzPath, int maxDimension, CancellationToken cancellationToken)
+    public async Task<TempResizedCbz> CreateResizedTempCbzAsync(string inputCbzPath, int maxDimension, CancellationToken cancellationToken)
     {
         if (!File.Exists(inputCbzPath))
         {
@@ -56,7 +56,7 @@ public class ImageResizeService : IImageResizeService
             
             _logger.LogInformation("Created resized temporary CBZ at {TempPath}", tempCbzPath);
             
-            return tempCbzPath;
+            return new TempResizedCbz(tempCbzPath, this);
         }
         finally
         {

--- a/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/ImageResizeService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/ImageResizeService.cs
@@ -1,0 +1,160 @@
+using MangaIngestWithUpscaling.Shared.Services.FileSystem;
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using System.IO.Compression;
+
+namespace MangaIngestWithUpscaling.Shared.Services.ImageProcessing;
+
+[RegisterScoped]
+public class ImageResizeService : IImageResizeService
+{
+    private readonly ILogger<ImageResizeService> _logger;
+    private readonly IFileSystem _fileSystem;
+    
+    private static readonly string[] SupportedImageExtensions = 
+    {
+        ".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tiff", ".tif"
+    };
+
+    public ImageResizeService(ILogger<ImageResizeService> logger, IFileSystem fileSystem)
+    {
+        _logger = logger;
+        _fileSystem = fileSystem;
+    }
+
+    public async Task<string> CreateResizedTempCbzAsync(string inputCbzPath, int maxDimension, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(inputCbzPath))
+        {
+            throw new FileNotFoundException($"Input CBZ file not found: {inputCbzPath}");
+        }
+
+        if (maxDimension <= 0)
+        {
+            throw new ArgumentException("Maximum dimension must be greater than 0", nameof(maxDimension));
+        }
+
+        // Create temporary directory for processing
+        string tempDir = Path.Combine(Path.GetTempPath(), $"manga_resize_{Guid.NewGuid()}");
+        string tempCbzPath = Path.Combine(Path.GetTempPath(), $"resized_{Path.GetFileName(inputCbzPath)}");
+
+        try
+        {
+            _fileSystem.CreateDirectory(tempDir);
+            
+            _logger.LogInformation("Resizing images in {InputPath} to max dimension {MaxDimension}", inputCbzPath, maxDimension);
+
+            // Extract CBZ to temporary directory
+            ZipFile.ExtractToDirectory(inputCbzPath, tempDir);
+
+            // Process all images in the extracted directory
+            await ProcessImagesInDirectory(tempDir, maxDimension, cancellationToken);
+
+            // Create new CBZ with resized images
+            ZipFile.CreateFromDirectory(tempDir, tempCbzPath);
+            
+            _logger.LogInformation("Created resized temporary CBZ at {TempPath}", tempCbzPath);
+            
+            return tempCbzPath;
+        }
+        finally
+        {
+            // Clean up temporary extraction directory
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    public void CleanupTempFile(string tempFilePath)
+    {
+        try
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+                _logger.LogDebug("Cleaned up temporary file: {TempFilePath}", tempFilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to clean up temporary file: {TempFilePath}", tempFilePath);
+        }
+    }
+
+    private async Task ProcessImagesInDirectory(string directory, int maxDimension, CancellationToken cancellationToken)
+    {
+        var imageFiles = Directory.GetFiles(directory, "*", SearchOption.AllDirectories)
+            .Where(f => SupportedImageExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+            .ToList();
+
+        _logger.LogDebug("Found {Count} image files to process", imageFiles.Count);
+
+        foreach (string imagePath in imageFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            
+            try
+            {
+                await ResizeImageIfNeeded(imagePath, maxDimension, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to resize image: {ImagePath}", imagePath);
+                // Continue processing other images even if one fails
+            }
+        }
+    }
+
+    private async Task ResizeImageIfNeeded(string imagePath, int maxDimension, CancellationToken cancellationToken)
+    {
+        using var image = await Image.LoadAsync(imagePath, cancellationToken);
+        
+        // Check if resizing is needed
+        if (image.Width <= maxDimension && image.Height <= maxDimension)
+        {
+            _logger.LogDebug("Image {ImagePath} ({Width}x{Height}) is already within bounds, skipping resize", 
+                imagePath, image.Width, image.Height);
+            return;
+        }
+
+        // Calculate new dimensions while maintaining aspect ratio
+        var (newWidth, newHeight) = CalculateNewDimensions(image.Width, image.Height, maxDimension);
+        
+        _logger.LogDebug("Resizing image {ImagePath} from {OriginalWidth}x{OriginalHeight} to {NewWidth}x{NewHeight}", 
+            imagePath, image.Width, image.Height, newWidth, newHeight);
+
+        // Resize the image
+        image.Mutate(x => x.Resize(newWidth, newHeight));
+        
+        // Save the resized image back to the same path
+        await image.SaveAsync(imagePath, cancellationToken);
+    }
+
+    private static (int width, int height) CalculateNewDimensions(int originalWidth, int originalHeight, int maxDimension)
+    {
+        if (originalWidth <= maxDimension && originalHeight <= maxDimension)
+        {
+            return (originalWidth, originalHeight);
+        }
+
+        double aspectRatio = (double)originalWidth / originalHeight;
+        
+        if (originalWidth > originalHeight)
+        {
+            // Width is the limiting dimension
+            int newWidth = maxDimension;
+            int newHeight = (int)Math.Round(newWidth / aspectRatio);
+            return (newWidth, newHeight);
+        }
+        else
+        {
+            // Height is the limiting dimension
+            int newHeight = maxDimension;
+            int newWidth = (int)Math.Round(newHeight * aspectRatio);
+            return (newWidth, newHeight);
+        }
+    }
+}

--- a/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/ImageResizeService.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/ImageResizeService.cs
@@ -37,7 +37,10 @@ public class ImageResizeService : IImageResizeService
 
         // Create temporary directory for processing
         string tempDir = Path.Combine(Path.GetTempPath(), $"manga_resize_{Guid.NewGuid()}");
-        string tempCbzPath = Path.Combine(Path.GetTempPath(), $"resized_{Path.GetFileName(inputCbzPath)}");
+        string tempCbzPath = Path.Combine(
+            Path.GetTempPath(),
+            $"resized_{Guid.NewGuid()}_{Path.GetFileName(inputCbzPath)}"
+        );
 
         try
         {

--- a/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/TempResizedCbz.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/TempResizedCbz.cs
@@ -22,6 +22,7 @@ public sealed class TempResizedCbz : IDisposable
         {
             _imageResizeService.CleanupTempFile(FilePath);
             _disposed = true;
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/TempResizedCbz.cs
+++ b/MangaIngestWithUpscaling.Shared/Services/ImageProcessing/TempResizedCbz.cs
@@ -1,0 +1,27 @@
+namespace MangaIngestWithUpscaling.Shared.Services.ImageProcessing;
+
+/// <summary>
+/// Disposable wrapper for a temporary resized CBZ file that automatically cleans up when disposed
+/// </summary>
+public sealed class TempResizedCbz : IDisposable
+{
+    private readonly IImageResizeService _imageResizeService;
+    private bool _disposed;
+
+    public string FilePath { get; }
+
+    internal TempResizedCbz(string filePath, IImageResizeService imageResizeService)
+    {
+        FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+        _imageResizeService = imageResizeService ?? throw new ArgumentNullException(nameof(imageResizeService));
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _imageResizeService.CleanupTempFile(FilePath);
+            _disposed = true;
+        }
+    }
+}

--- a/MangaIngestWithUpscaling/appsettings.json
+++ b/MangaIngestWithUpscaling/appsettings.json
@@ -31,7 +31,8 @@
   //   "UseCPU": false,
   //   "SelectedDeviceIndex": 0,
   //   "RemoteOnly": false,
-  //   "PreferredGpuBackend": "Auto" // Options: "Auto", "CUDA", "ROCm", "XPU", "CPU"
+  //   "PreferredGpuBackend": "Auto", // Options: "Auto", "CUDA", "ROCm", "XPU", "CPU"
+  //   "MaxDimensionBeforeUpscaling": null // Optional: Set to a number (e.g., 2048) to resize images larger than this dimension before upscaling
   // },
   "OIDC": {
     "Enabled": false,


### PR DESCRIPTION
Allows defining a limit on how big images are allowed to be in order to prevent timeouts, bugs etc. via the config.

If a dimension exceeds it, the image is scaled down so that it fits again.