### PR TITLE
Fix task reordering

### DIFF
--- a/.run/Full_Stack.run.xml
+++ b/.run/Full_Stack.run.xml
@@ -5,4 +5,3 @@
     <method v="2" />
   </configuration>
 </component>
-

--- a/.run/Server.run.xml
+++ b/.run/Server.run.xml
@@ -1,6 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Server" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
-    <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj" />
+  <configuration
+    default="false"
+    name="Server"
+    type="LaunchSettings"
+    factoryName=".NET Launch Settings Profile"
+  >
+    <option
+      name="LAUNCH_PROFILE_PROJECT_FILE_PATH"
+      value="$PROJECT_DIR$/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj"
+    />
     <option name="LAUNCH_PROFILE_TFM" value="net10.0" />
     <option name="LAUNCH_PROFILE_NAME" value="https (remote only)" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
@@ -15,4 +23,3 @@
     </method>
   </configuration>
 </component>
-

--- a/.run/Worker.run.xml
+++ b/.run/Worker.run.xml
@@ -1,6 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Worker" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
-    <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/src/MangaIngestWithUpscaling.RemoteWorker/MangaIngestWithUpscaling.RemoteWorker.csproj" />
+  <configuration
+    default="false"
+    name="Worker"
+    type="LaunchSettings"
+    factoryName=".NET Launch Settings Profile"
+  >
+    <option
+      name="LAUNCH_PROFILE_PROJECT_FILE_PATH"
+      value="$PROJECT_DIR$/src/MangaIngestWithUpscaling.RemoteWorker/MangaIngestWithUpscaling.RemoteWorker.csproj"
+    />
     <option name="LAUNCH_PROFILE_TFM" value="net10.0" />
     <option name="LAUNCH_PROFILE_NAME" value="https" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
@@ -15,4 +23,3 @@
     </method>
   </configuration>
 </component>
-

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -173,20 +173,26 @@ public class DistributedUpscaleTaskProcessor(
                 bool completed = false;
                 while (!completed && !stoppingToken.IsCancellationRequested)
                 {
-                    try
-                    {
-                        await _reader.ReadAsync(linkedCts.Token);
-                    }
-                    catch (OperationCanceledException)
-                        when (linkedCts.IsCancellationRequested
-                            && !stoppingToken.IsCancellationRequested
-                        )
-                    {
-                        // The specific request timed out or was cancelled, but the processor should keep running.
-                        break;
-                    }
-
                     PersistedTask? task = taskQueue.DequeueUpscale();
+
+                    if (task == null)
+                    {
+                        try
+                        {
+                            await _reader.WaitToReadAsync(linkedCts.Token);
+                            _reader.TryRead(out _);
+                        }
+                        catch (OperationCanceledException)
+                            when (linkedCts.IsCancellationRequested
+                                && !stoppingToken.IsCancellationRequested
+                            )
+                        {
+                            // The specific request timed out or was cancelled, but the processor should keep running.
+                            break;
+                        }
+
+                        task = taskQueue.DequeueUpscale();
+                    }
 
                     if (task == null)
                     {

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -173,7 +173,19 @@ public class DistributedUpscaleTaskProcessor(
                 bool completed = false;
                 while (!completed && !stoppingToken.IsCancellationRequested)
                 {
-                    await _reader.ReadAsync(linkedCts.Token);
+                    try
+                    {
+                        await _reader.ReadAsync(linkedCts.Token);
+                    }
+                    catch (OperationCanceledException)
+                        when (linkedCts.IsCancellationRequested
+                            && !stoppingToken.IsCancellationRequested
+                        )
+                    {
+                        // The specific request timed out or was cancelled, but the processor should keep running.
+                        break;
+                    }
+
                     PersistedTask? task = taskQueue.DequeueUpscale();
 
                     if (task == null)

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -173,26 +173,20 @@ public class DistributedUpscaleTaskProcessor(
                 bool completed = false;
                 while (!completed && !stoppingToken.IsCancellationRequested)
                 {
-                    PersistedTask? task = taskQueue.DequeueUpscale();
-
-                    if (task == null)
+                    try
                     {
-                        try
-                        {
-                            await _reader.WaitToReadAsync(linkedCts.Token);
-                            _reader.TryRead(out _);
-                        }
-                        catch (OperationCanceledException)
-                            when (linkedCts.IsCancellationRequested
-                                && !stoppingToken.IsCancellationRequested
-                            )
-                        {
-                            // The specific request timed out or was cancelled, but the processor should keep running.
-                            break;
-                        }
-
-                        task = taskQueue.DequeueUpscale();
+                        await _reader.ReadAsync(linkedCts.Token);
                     }
+                    catch (OperationCanceledException)
+                        when (linkedCts.IsCancellationRequested
+                            && !stoppingToken.IsCancellationRequested
+                        )
+                    {
+                        // The specific request timed out or was cancelled, but the processor should keep running.
+                        break;
+                    }
+
+                    PersistedTask? task = taskQueue.DequeueUpscale();
 
                     if (task == null)
                     {

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -27,7 +27,7 @@ public class DistributedUpscaleTaskProcessor(
 ) : BackgroundService
 {
     private readonly Lock _lock = new();
-    private readonly ChannelReader<PersistedTask> _reader = taskQueue.UpscaleReader;
+    private readonly ChannelReader<object> _reader = taskQueue.UpscaleReader;
 
     private readonly Channel<(
         TaskCompletionSource<PersistedTask>,
@@ -173,7 +173,13 @@ public class DistributedUpscaleTaskProcessor(
                 bool completed = false;
                 while (!completed && !stoppingToken.IsCancellationRequested)
                 {
-                    PersistedTask task = await _reader.ReadAsync(linkedCts.Token);
+                    await _reader.ReadAsync(linkedCts.Token);
+                    PersistedTask? task = taskQueue.DequeueUpscale();
+
+                    if (task == null)
+                    {
+                        continue;
+                    }
 
                     bool taskClaimed = false;
                     using (IServiceScope scope = scopeFactory.CreateScope())

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/StandardTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/StandardTaskProcessor.cs
@@ -14,7 +14,7 @@ public class StandardTaskProcessor(
 {
     private readonly Lock _lock = new();
     private readonly TimeSpan _progressDebounce = TimeSpan.FromMilliseconds(250);
-    private readonly ChannelReader<PersistedTask> _reader = taskQueue.StandardReader;
+    private readonly ChannelReader<object> _reader = taskQueue.StandardReader;
     private CancellationTokenSource? currentStoppingToken;
     private PersistedTask? currentTask;
     private CancellationToken serviceStoppingToken;
@@ -43,7 +43,14 @@ public class StandardTaskProcessor(
         serviceStoppingToken = stoppingToken;
         while (!stoppingToken.IsCancellationRequested)
         {
-            var task = await _reader.ReadAsync(stoppingToken);
+            await _reader.ReadAsync(stoppingToken);
+            var task = taskQueue.DequeueStandard();
+
+            if (task == null)
+            {
+                continue;
+            }
+
             using (_lock.EnterScope())
             {
                 currentStoppingToken = CancellationTokenSource.CreateLinkedTokenSource(

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/StandardTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/StandardTaskProcessor.cs
@@ -43,16 +43,8 @@ public class StandardTaskProcessor(
         serviceStoppingToken = stoppingToken;
         while (!stoppingToken.IsCancellationRequested)
         {
-            // Check for tasks first before waiting for a signal
+            await _reader.ReadAsync(stoppingToken);
             var task = taskQueue.DequeueStandard();
-
-            if (task == null)
-            {
-                // Wait for a pulse signal and then consume it
-                await _reader.WaitToReadAsync(stoppingToken);
-                _reader.TryRead(out _);
-                task = taskQueue.DequeueStandard();
-            }
 
             if (task == null)
             {

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/StandardTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/StandardTaskProcessor.cs
@@ -43,8 +43,16 @@ public class StandardTaskProcessor(
         serviceStoppingToken = stoppingToken;
         while (!stoppingToken.IsCancellationRequested)
         {
-            await _reader.ReadAsync(stoppingToken);
+            // Check for tasks first before waiting for a signal
             var task = taskQueue.DequeueStandard();
+
+            if (task == null)
+            {
+                // Wait for a pulse signal and then consume it
+                await _reader.WaitToReadAsync(stoppingToken);
+                _reader.TryRead(out _);
+                task = taskQueue.DequeueStandard();
+            }
 
             if (task == null)
             {

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -45,17 +45,9 @@ public class TaskQueue : ITaskQueue, IHostedService
         _scopeFactory = scopeFactory;
         _logger = logger;
 
-        // Use bounded channels of size 1 with DropWrite for coalescing signals.
-        // A single signal in the channel notifies processors that "at least one task is available".
-        // Processors must drain the queue until Dequeue* returns null.
-        var signalOptions = new BoundedChannelOptions(1)
-        {
-            FullMode = BoundedChannelFullMode.DropWrite,
-            SingleReader = false,
-            SingleWriter = false,
-        };
-        _standardChannel = Channel.CreateBounded<object>(signalOptions);
-        _upscaleChannel = Channel.CreateBounded<object>(signalOptions);
+        // Use unbounded channels for signals; signals do not carry tasks, but notify consumers to pull from sorted sets.
+        _standardChannel = Channel.CreateUnbounded<object>();
+        _upscaleChannel = Channel.CreateUnbounded<object>();
         // Reroute channel remains carrying tasks: it's fed only by DistributedUpscaleTaskProcessor and consumed by the local UpscaleTaskProcessor
         _reroutedUpscaleChannel = Channel.CreateUnbounded<PersistedTask>();
 
@@ -333,40 +325,32 @@ public class TaskQueue : ITaskQueue, IHostedService
             }
         }
 
-        bool standardAdded = false;
-        bool upscaleAdded = false;
-
         foreach (var task in pendingTasks)
         {
             if (IsUpscaleTask(task.Data))
             {
+                bool added;
                 lock (_upscaleTasksLock)
                 {
-                    if (_upscaleTasks.Add(task))
-                    {
-                        upscaleAdded = true;
-                    }
+                    added = _upscaleTasks.Add(task);
+                }
+                if (added)
+                {
+                    _upscaleChannel.Writer.TryWrite(Signal);
                 }
             }
             else
             {
+                bool added;
                 lock (_standardTasksLock)
                 {
-                    if (_standardTasks.Add(task))
-                    {
-                        standardAdded = true;
-                    }
+                    added = _standardTasks.Add(task);
+                }
+                if (added)
+                {
+                    _standardChannel.Writer.TryWrite(Signal);
                 }
             }
-        }
-
-        if (standardAdded)
-        {
-            _standardChannel.Writer.TryWrite(Signal);
-        }
-        if (upscaleAdded)
-        {
-            _upscaleChannel.Writer.TryWrite(Signal);
         }
     }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -31,6 +31,7 @@ public interface ITaskQueue
 
 public class TaskQueue : ITaskQueue, IHostedService
 {
+    private static readonly object Signal = new();
     private readonly ILogger<TaskQueue> _logger;
     private readonly Channel<PersistedTask> _reroutedUpscaleChannel;
     private readonly IServiceScopeFactory _scopeFactory;
@@ -129,7 +130,7 @@ public class TaskQueue : ITaskQueue, IHostedService
             {
                 _upscaleTasks.Add(taskItem);
             }
-            await _upscaleChannel.Writer.WriteAsync(new object());
+            await _upscaleChannel.Writer.WriteAsync(Signal);
         }
         else
         {
@@ -137,7 +138,7 @@ public class TaskQueue : ITaskQueue, IHostedService
             {
                 _standardTasks.Add(taskItem);
             }
-            await _standardChannel.Writer.WriteAsync(new object());
+            await _standardChannel.Writer.WriteAsync(Signal);
         }
 
         TaskEnqueuedOrChanged?.Invoke(taskItem);
@@ -254,7 +255,7 @@ public class TaskQueue : ITaskQueue, IHostedService
             {
                 _upscaleTasks.Add(task);
             }
-            await _upscaleChannel.Writer.WriteAsync(new object());
+            await _upscaleChannel.Writer.WriteAsync(Signal);
         }
         else
         {
@@ -262,7 +263,7 @@ public class TaskQueue : ITaskQueue, IHostedService
             {
                 _standardTasks.Add(task);
             }
-            await _standardChannel.Writer.WriteAsync(new object());
+            await _standardChannel.Writer.WriteAsync(Signal);
         }
 
         TaskEnqueuedOrChanged?.Invoke(task);
@@ -292,7 +293,7 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     _upscaleTasks.Add(task);
                 }
-                _upscaleChannel.Writer.TryWrite(new object());
+                _upscaleChannel.Writer.TryWrite(Signal);
             }
             else
             {
@@ -300,7 +301,7 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     _standardTasks.Add(task);
                 }
-                _standardChannel.Writer.TryWrite(new object());
+                _standardChannel.Writer.TryWrite(Signal);
             }
         }
     }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -126,19 +126,27 @@ public class TaskQueue : ITaskQueue, IHostedService
                 or ApplySplitsTask
         )
         {
+            bool added;
             lock (_upscaleTasksLock)
             {
-                _upscaleTasks.Add(taskItem);
+                added = _upscaleTasks.Add(taskItem);
             }
-            await _upscaleChannel.Writer.WriteAsync(Signal);
+            if (added)
+            {
+                await _upscaleChannel.Writer.WriteAsync(Signal);
+            }
         }
         else
         {
+            bool added;
             lock (_standardTasksLock)
             {
-                _standardTasks.Add(taskItem);
+                added = _standardTasks.Add(taskItem);
             }
-            await _standardChannel.Writer.WriteAsync(Signal);
+            if (added)
+            {
+                await _standardChannel.Writer.WriteAsync(Signal);
+            }
         }
 
         TaskEnqueuedOrChanged?.Invoke(taskItem);
@@ -249,21 +257,36 @@ public class TaskQueue : ITaskQueue, IHostedService
         dbContext.Update(task);
         await dbContext.SaveChangesAsync();
 
-        if (task.Data is UpscaleTask or RenameUpscaledChaptersSeriesTask or RepairUpscaleTask)
+        if (
+            task.Data
+            is UpscaleTask
+                or RenameUpscaledChaptersSeriesTask
+                or RepairUpscaleTask
+                or DetectSplitCandidatesTask
+                or ApplySplitsTask
+        )
         {
+            bool added;
             lock (_upscaleTasksLock)
             {
-                _upscaleTasks.Add(task);
+                added = _upscaleTasks.Add(task);
             }
-            await _upscaleChannel.Writer.WriteAsync(Signal);
+            if (added)
+            {
+                await _upscaleChannel.Writer.WriteAsync(Signal);
+            }
         }
         else
         {
+            bool added;
             lock (_standardTasksLock)
             {
-                _standardTasks.Add(task);
+                added = _standardTasks.Add(task);
             }
-            await _standardChannel.Writer.WriteAsync(Signal);
+            if (added)
+            {
+                await _standardChannel.Writer.WriteAsync(Signal);
+            }
         }
 
         TaskEnqueuedOrChanged?.Invoke(task);
@@ -287,21 +310,36 @@ public class TaskQueue : ITaskQueue, IHostedService
         // Load tasks into sorted sets and signal their presence
         foreach (var task in pendingTasks)
         {
-            if (task.Data is UpscaleTask or RenameUpscaledChaptersSeriesTask or RepairUpscaleTask)
+            if (
+                task.Data
+                is UpscaleTask
+                    or RenameUpscaledChaptersSeriesTask
+                    or RepairUpscaleTask
+                    or DetectSplitCandidatesTask
+                    or ApplySplitsTask
+            )
             {
+                bool added;
                 lock (_upscaleTasksLock)
                 {
-                    _upscaleTasks.Add(task);
+                    added = _upscaleTasks.Add(task);
                 }
-                _upscaleChannel.Writer.TryWrite(Signal);
+                if (added)
+                {
+                    _upscaleChannel.Writer.TryWrite(Signal);
+                }
             }
             else
             {
+                bool added;
                 lock (_standardTasksLock)
                 {
-                    _standardTasks.Add(task);
+                    added = _standardTasks.Add(task);
                 }
-                _standardChannel.Writer.TryWrite(Signal);
+                if (added)
+                {
+                    _standardChannel.Writer.TryWrite(Signal);
+                }
             }
         }
     }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -300,6 +300,7 @@ public class TaskQueue : ITaskQueue, IHostedService
 
         // Load tasks into sorted sets and signal their presence
         bool dbChanged = false;
+        var changedTasks = new List<PersistedTask>();
         foreach (var task in pendingTasks)
         {
             if (task.Status == PersistedTaskStatus.Failed)
@@ -307,6 +308,7 @@ public class TaskQueue : ITaskQueue, IHostedService
                 task.Status = PersistedTaskStatus.Pending;
                 dbContext.Update(task);
                 dbChanged = true;
+                changedTasks.Add(task);
             }
         }
 
@@ -315,7 +317,16 @@ public class TaskQueue : ITaskQueue, IHostedService
             // Save status changes before they are added to the in-memory queue and signaled.
             // This prevents a processor from seeing the old 'Failed' status if it wakes up immediately.
             await dbContext.SaveChangesAsync(cancellationToken);
+
+            // Notify listeners (TaskRegistry/UI) that Failed tasks are now Pending
+            foreach (var task in changedTasks)
+            {
+                TaskEnqueuedOrChanged?.Invoke(task);
+            }
         }
+
+        bool standardSignaled = false;
+        bool upscaleSignaled = false;
 
         foreach (var task in pendingTasks)
         {
@@ -326,9 +337,10 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     added = _upscaleTasks.Add(task);
                 }
-                if (added)
+                if (added && !upscaleSignaled)
                 {
                     _upscaleChannel.Writer.TryWrite(Signal);
+                    upscaleSignaled = true;
                 }
             }
             else
@@ -338,9 +350,10 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     added = _standardTasks.Add(task);
                 }
-                if (added)
+                if (added && !standardSignaled)
                 {
                     _standardChannel.Writer.TryWrite(Signal);
+                    standardSignaled = true;
                 }
             }
         }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -283,11 +283,15 @@ public class TaskQueue : ITaskQueue, IHostedService
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         // Only consider Pending and retryable Failed tasks here; we will explicitly recover stranded Processing elsewhere
-        var allTasks = await dbContext
-            .PersistedTasks.OrderBy(t => t.Order)
+        // Filter by Status in DB to avoid full table scan
+        var candidateTasks = await dbContext
+            .PersistedTasks.Where(t =>
+                t.Status == PersistedTaskStatus.Pending || t.Status == PersistedTaskStatus.Failed
+            )
+            .OrderBy(t => t.Order)
             .ToListAsync(cancellationToken);
 
-        var pendingTasks = allTasks
+        var pendingTasks = candidateTasks
             .Where(t =>
                 t.Status == PersistedTaskStatus.Pending
                 || (t.Status == PersistedTaskStatus.Failed && t.RetryCount < t.Data.RetryFor)
@@ -304,7 +308,17 @@ public class TaskQueue : ITaskQueue, IHostedService
                 dbContext.Update(task);
                 dbChanged = true;
             }
+        }
 
+        if (dbChanged)
+        {
+            // Save status changes before they are added to the in-memory queue and signaled.
+            // This prevents a processor from seeing the old 'Failed' status if it wakes up immediately.
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        foreach (var task in pendingTasks)
+        {
             if (IsUpscaleTask(task.Data))
             {
                 bool added;
@@ -329,11 +343,6 @@ public class TaskQueue : ITaskQueue, IHostedService
                     _standardChannel.Writer.TryWrite(Signal);
                 }
             }
-        }
-
-        if (dbChanged)
-        {
-            await dbContext.SaveChangesAsync(cancellationToken);
         }
     }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -45,9 +45,17 @@ public class TaskQueue : ITaskQueue, IHostedService
         _scopeFactory = scopeFactory;
         _logger = logger;
 
-        // Use unbounded channels for signals; signals do not carry tasks, but notify consumers to pull from sorted sets.
-        _standardChannel = Channel.CreateUnbounded<object>();
-        _upscaleChannel = Channel.CreateUnbounded<object>();
+        // Use bounded channels of size 1 with DropWrite for coalescing signals.
+        // A single signal in the channel notifies processors that "at least one task is available".
+        // Processors must drain the queue until Dequeue* returns null.
+        var signalOptions = new BoundedChannelOptions(1)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = false,
+            SingleWriter = false,
+        };
+        _standardChannel = Channel.CreateBounded<object>(signalOptions);
+        _upscaleChannel = Channel.CreateBounded<object>(signalOptions);
         // Reroute channel remains carrying tasks: it's fed only by DistributedUpscaleTaskProcessor and consumed by the local UpscaleTaskProcessor
         _reroutedUpscaleChannel = Channel.CreateUnbounded<PersistedTask>();
 
@@ -325,32 +333,40 @@ public class TaskQueue : ITaskQueue, IHostedService
             }
         }
 
+        bool standardAdded = false;
+        bool upscaleAdded = false;
+
         foreach (var task in pendingTasks)
         {
             if (IsUpscaleTask(task.Data))
             {
-                bool added;
                 lock (_upscaleTasksLock)
                 {
-                    added = _upscaleTasks.Add(task);
-                }
-                if (added)
-                {
-                    _upscaleChannel.Writer.TryWrite(Signal);
+                    if (_upscaleTasks.Add(task))
+                    {
+                        upscaleAdded = true;
+                    }
                 }
             }
             else
             {
-                bool added;
                 lock (_standardTasksLock)
                 {
-                    added = _standardTasks.Add(task);
-                }
-                if (added)
-                {
-                    _standardChannel.Writer.TryWrite(Signal);
+                    if (_standardTasks.Add(task))
+                    {
+                        standardAdded = true;
+                    }
                 }
             }
+        }
+
+        if (standardAdded)
+        {
+            _standardChannel.Writer.TryWrite(Signal);
+        }
+        if (upscaleAdded)
+        {
+            _upscaleChannel.Writer.TryWrite(Signal);
         }
     }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -22,6 +22,9 @@ public interface ITaskQueue
 
     IReadOnlyList<PersistedTask> GetUpscaleSnapshot();
 
+    PersistedTask? DequeueStandard();
+    PersistedTask? DequeueUpscale();
+
     // Convenience to move a task to the front of its queue safely
     Task MoveToFrontAsync(PersistedTask task, CancellationToken cancellationToken = default);
 }
@@ -31,11 +34,11 @@ public class TaskQueue : ITaskQueue, IHostedService
     private readonly ILogger<TaskQueue> _logger;
     private readonly Channel<PersistedTask> _reroutedUpscaleChannel;
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly Channel<PersistedTask> _standardChannel;
+    private readonly Channel<object> _standardChannel;
 
     private readonly SortedSet<PersistedTask> _standardTasks;
     private readonly object _standardTasksLock = new();
-    private readonly Channel<PersistedTask> _upscaleChannel;
+    private readonly Channel<object> _upscaleChannel;
     private readonly SortedSet<PersistedTask> _upscaleTasks;
     private readonly object _upscaleTasksLock = new();
 
@@ -44,14 +47,10 @@ public class TaskQueue : ITaskQueue, IHostedService
         _scopeFactory = scopeFactory;
         _logger = logger;
 
-        // Create bounded channels to control concurrency
-        var channelOptions = new BoundedChannelOptions(1)
-        {
-            FullMode = BoundedChannelFullMode.Wait,
-        };
-        _standardChannel = Channel.CreateBounded<PersistedTask>(channelOptions);
-        _upscaleChannel = Channel.CreateBounded<PersistedTask>(channelOptions);
-        // Reroute channel is unbounded: it's fed only by DistributedUpscaleTaskProcessor and consumed by the local UpscaleTaskProcessor
+        // Use unbounded channels for signals; signals do not carry tasks, but notify consumers to pull from sorted sets.
+        _standardChannel = Channel.CreateUnbounded<object>();
+        _upscaleChannel = Channel.CreateUnbounded<object>();
+        // Reroute channel remains carrying tasks: it's fed only by DistributedUpscaleTaskProcessor and consumed by the local UpscaleTaskProcessor
         _reroutedUpscaleChannel = Channel.CreateUnbounded<PersistedTask>();
 
         // Initialize sorted sets with a stable comparer
@@ -75,27 +74,13 @@ public class TaskQueue : ITaskQueue, IHostedService
         _upscaleTasks = new SortedSet<PersistedTask>(comparer);
     }
 
-    public ChannelReader<PersistedTask> StandardReader => _standardChannel.Reader;
-    public ChannelReader<PersistedTask> UpscaleReader => _upscaleChannel.Reader;
+    public ChannelReader<object> StandardReader => _standardChannel.Reader;
+    public ChannelReader<object> UpscaleReader => _upscaleChannel.Reader;
     public ChannelReader<PersistedTask> ReroutedUpscaleReader => _reroutedUpscaleChannel.Reader;
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         await ReplayPendingOrFailed(cancellationToken);
-
-        // Start background processing
-        _ = ProcessChannelAsync(
-            _standardChannel,
-            _standardTasks,
-            _standardTasksLock,
-            cancellationToken
-        );
-        _ = ProcessChannelAsync(
-            _upscaleChannel,
-            _upscaleTasks,
-            _upscaleTasksLock,
-            cancellationToken
-        );
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
@@ -130,7 +115,7 @@ public class TaskQueue : ITaskQueue, IHostedService
         await dbContext.PersistedTasks.AddAsync(taskItem);
         await dbContext.SaveChangesAsync();
 
-        // Add to the appropriate sorted set
+        // Add to the appropriate sorted set and notify via signal
         if (
             taskData
             is UpscaleTask
@@ -144,6 +129,7 @@ public class TaskQueue : ITaskQueue, IHostedService
             {
                 _upscaleTasks.Add(taskItem);
             }
+            await _upscaleChannel.Writer.WriteAsync(new object());
         }
         else
         {
@@ -151,6 +137,7 @@ public class TaskQueue : ITaskQueue, IHostedService
             {
                 _standardTasks.Add(taskItem);
             }
+            await _standardChannel.Writer.WriteAsync(new object());
         }
 
         TaskEnqueuedOrChanged?.Invoke(taskItem);
@@ -261,16 +248,21 @@ public class TaskQueue : ITaskQueue, IHostedService
         dbContext.Update(task);
         await dbContext.SaveChangesAsync();
 
-        (SortedSet<PersistedTask> tasks, object lockObj) = task.Data
-            is UpscaleTask
-                or RenameUpscaledChaptersSeriesTask
-                or RepairUpscaleTask
-            ? (_upscaleTasks, _upscaleTasksLock)
-            : (_standardTasks, _standardTasksLock);
-
-        lock (lockObj)
+        if (task.Data is UpscaleTask or RenameUpscaledChaptersSeriesTask or RepairUpscaleTask)
         {
-            tasks.Add(task);
+            lock (_upscaleTasksLock)
+            {
+                _upscaleTasks.Add(task);
+            }
+            await _upscaleChannel.Writer.WriteAsync(new object());
+        }
+        else
+        {
+            lock (_standardTasksLock)
+            {
+                _standardTasks.Add(task);
+            }
+            await _standardChannel.Writer.WriteAsync(new object());
         }
 
         TaskEnqueuedOrChanged?.Invoke(task);
@@ -291,19 +283,49 @@ public class TaskQueue : ITaskQueue, IHostedService
             )
             .ToListAsync(cancellationToken);
 
-        // Load tasks into sorted sets
+        // Load tasks into sorted sets and signal their presence
         foreach (var task in pendingTasks)
         {
             if (task.Data is UpscaleTask or RenameUpscaledChaptersSeriesTask or RepairUpscaleTask)
             {
                 lock (_upscaleTasksLock)
+                {
                     _upscaleTasks.Add(task);
+                }
+                _upscaleChannel.Writer.TryWrite(new object());
             }
             else
             {
                 lock (_standardTasksLock)
+                {
                     _standardTasks.Add(task);
+                }
+                _standardChannel.Writer.TryWrite(new object());
             }
+        }
+    }
+
+    public PersistedTask? DequeueStandard()
+    {
+        lock (_standardTasksLock)
+        {
+            if (_standardTasks.Count == 0)
+                return null;
+            var task = _standardTasks.Min;
+            _standardTasks.Remove(task!);
+            return task;
+        }
+    }
+
+    public PersistedTask? DequeueUpscale()
+    {
+        lock (_upscaleTasksLock)
+        {
+            if (_upscaleTasks.Count == 0)
+                return null;
+            var task = _upscaleTasks.Min;
+            _upscaleTasks.Remove(task!);
+            return task;
         }
     }
 
@@ -318,34 +340,4 @@ public class TaskQueue : ITaskQueue, IHostedService
 
     public event Func<PersistedTask, Task>? TaskEnqueuedOrChanged;
     public event Func<PersistedTask, Task>? TaskRemoved;
-
-    private async Task ProcessChannelAsync(
-        Channel<PersistedTask> channel,
-        SortedSet<PersistedTask> tasks,
-        object lockObj,
-        CancellationToken cancellationToken
-    )
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            PersistedTask? task = null;
-            lock (lockObj)
-            {
-                if (tasks.Count > 0)
-                {
-                    task = tasks.Min;
-                    tasks.Remove(task!);
-                }
-            }
-
-            if (task != null)
-            {
-                await channel.Writer.WriteAsync(task, cancellationToken);
-            }
-            else
-            {
-                await Task.Delay(100, cancellationToken);
-            }
-        }
-    }
 }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -100,6 +100,14 @@ public class TaskQueue : ITaskQueue, IHostedService
         }
     }
 
+    public static bool IsUpscaleTask(BaseTask data) =>
+        data
+            is UpscaleTask
+                or RenameUpscaledChaptersSeriesTask
+                or RepairUpscaleTask
+                or DetectSplitCandidatesTask
+                or ApplySplitsTask;
+
     public async Task EnqueueAsync<T>(T taskData)
         where T : BaseTask
     {
@@ -114,14 +122,7 @@ public class TaskQueue : ITaskQueue, IHostedService
         await dbContext.SaveChangesAsync();
 
         // Add to the appropriate sorted set and notify via signal
-        if (
-            taskData
-            is UpscaleTask
-                or RenameUpscaledChaptersSeriesTask
-                or RepairUpscaleTask
-                or DetectSplitCandidatesTask
-                or ApplySplitsTask
-        )
+        if (IsUpscaleTask(taskData))
         {
             bool added;
             lock (_upscaleTasksLock)
@@ -165,12 +166,7 @@ public class TaskQueue : ITaskQueue, IHostedService
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         // Determine which set to modify
-        (SortedSet<PersistedTask> tasks, object lockObj) = task.Data
-            is UpscaleTask
-                or RenameUpscaledChaptersSeriesTask
-                or RepairUpscaleTask
-                or DetectSplitCandidatesTask
-                or ApplySplitsTask
+        (SortedSet<PersistedTask> tasks, object lockObj) = IsUpscaleTask(task.Data)
             ? (_upscaleTasks, _upscaleTasksLock)
             : (_standardTasks, _standardTasksLock);
 
@@ -229,12 +225,7 @@ public class TaskQueue : ITaskQueue, IHostedService
         dbContext.PersistedTasks.Remove(task);
         await dbContext.SaveChangesAsync();
 
-        (SortedSet<PersistedTask> tasks, object lockObj) = task.Data
-            is UpscaleTask
-                or RenameUpscaledChaptersSeriesTask
-                or RepairUpscaleTask
-                or DetectSplitCandidatesTask
-                or ApplySplitsTask
+        (SortedSet<PersistedTask> tasks, object lockObj) = IsUpscaleTask(task.Data)
             ? (_upscaleTasks, _upscaleTasksLock)
             : (_standardTasks, _standardTasksLock);
 
@@ -258,14 +249,7 @@ public class TaskQueue : ITaskQueue, IHostedService
         dbContext.Update(task);
         await dbContext.SaveChangesAsync();
 
-        if (
-            task.Data
-            is UpscaleTask
-                or RenameUpscaledChaptersSeriesTask
-                or RepairUpscaleTask
-                or DetectSplitCandidatesTask
-                or ApplySplitsTask
-        )
+        if (IsUpscaleTask(task.Data))
         {
             bool added;
             lock (_upscaleTasksLock)
@@ -299,26 +283,29 @@ public class TaskQueue : ITaskQueue, IHostedService
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         // Only consider Pending and retryable Failed tasks here; we will explicitly recover stranded Processing elsewhere
-        var pendingTasks = await dbContext
+        var allTasks = await dbContext
             .PersistedTasks.OrderBy(t => t.Order)
-            .AsAsyncEnumerable()
+            .ToListAsync(cancellationToken);
+
+        var pendingTasks = allTasks
             .Where(t =>
                 t.Status == PersistedTaskStatus.Pending
                 || (t.Status == PersistedTaskStatus.Failed && t.RetryCount < t.Data.RetryFor)
             )
-            .ToListAsync(cancellationToken);
+            .ToList();
 
         // Load tasks into sorted sets and signal their presence
+        bool dbChanged = false;
         foreach (var task in pendingTasks)
         {
-            if (
-                task.Data
-                is UpscaleTask
-                    or RenameUpscaledChaptersSeriesTask
-                    or RepairUpscaleTask
-                    or DetectSplitCandidatesTask
-                    or ApplySplitsTask
-            )
+            if (task.Status == PersistedTaskStatus.Failed)
+            {
+                task.Status = PersistedTaskStatus.Pending;
+                dbContext.Update(task);
+                dbChanged = true;
+            }
+
+            if (IsUpscaleTask(task.Data))
             {
                 bool added;
                 lock (_upscaleTasksLock)
@@ -342,6 +329,11 @@ public class TaskQueue : ITaskQueue, IHostedService
                     _standardChannel.Writer.TryWrite(Signal);
                 }
             }
+        }
+
+        if (dbChanged)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
         }
     }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -22,9 +22,6 @@ public interface ITaskQueue
 
     IReadOnlyList<PersistedTask> GetUpscaleSnapshot();
 
-    PersistedTask? DequeueStandard();
-    PersistedTask? DequeueUpscale();
-
     // Convenience to move a task to the front of its queue safely
     Task MoveToFrontAsync(PersistedTask task, CancellationToken cancellationToken = default);
 }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -325,9 +325,6 @@ public class TaskQueue : ITaskQueue, IHostedService
             }
         }
 
-        bool standardSignaled = false;
-        bool upscaleSignaled = false;
-
         foreach (var task in pendingTasks)
         {
             if (IsUpscaleTask(task.Data))
@@ -337,10 +334,9 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     added = _upscaleTasks.Add(task);
                 }
-                if (added && !upscaleSignaled)
+                if (added)
                 {
                     _upscaleChannel.Writer.TryWrite(Signal);
-                    upscaleSignaled = true;
                 }
             }
             else
@@ -350,10 +346,9 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     added = _standardTasks.Add(task);
                 }
-                if (added && !standardSignaled)
+                if (added)
                 {
                     _standardChannel.Writer.TryWrite(Signal);
-                    standardSignaled = true;
                 }
             }
         }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -172,6 +172,8 @@ public class TaskQueue : ITaskQueue, IHostedService
             is UpscaleTask
                 or RenameUpscaledChaptersSeriesTask
                 or RepairUpscaleTask
+                or DetectSplitCandidatesTask
+                or ApplySplitsTask
             ? (_upscaleTasks, _upscaleTasksLock)
             : (_standardTasks, _standardTasksLock);
 
@@ -234,6 +236,8 @@ public class TaskQueue : ITaskQueue, IHostedService
             is UpscaleTask
                 or RenameUpscaledChaptersSeriesTask
                 or RepairUpscaleTask
+                or DetectSplitCandidatesTask
+                or ApplySplitsTask
             ? (_upscaleTasks, _upscaleTasksLock)
             : (_standardTasks, _standardTasksLock);
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskRegistry.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskRegistry.cs
@@ -41,14 +41,7 @@ public class TaskRegistry : IHostedService, IDisposable
         // Standard view: non-upscale tasks, sorted by status priority, then Order, then CreatedAt
         _tasks
             .Connect()
-            .Filter(t =>
-                t.Data
-                    is not UpscaleTask
-                        and not RenameUpscaledChaptersSeriesTask
-                        and not RepairUpscaleTask
-                        and not DetectSplitCandidatesTask
-                        and not ApplySplitsTask
-            )
+            .Filter(t => !TaskQueue.IsUpscaleTask(t.Data))
             .SortAndBind(
                 out ReadOnlyObservableCollection<PersistedTask> standard,
                 SortExpressionComparer<PersistedTask>
@@ -63,14 +56,7 @@ public class TaskRegistry : IHostedService, IDisposable
         // Upscale view: upscale tasks, sorted by status priority, then Order, then CreatedAt
         _tasks
             .Connect()
-            .Filter(t =>
-                t.Data
-                    is UpscaleTask
-                        or RenameUpscaledChaptersSeriesTask
-                        or RepairUpscaleTask
-                        or DetectSplitCandidatesTask
-                        or ApplySplitsTask
-            )
+            .Filter(t => TaskQueue.IsUpscaleTask(t.Data))
             .SortAndBind(
                 out ReadOnlyObservableCollection<PersistedTask> upscale,
                 SortExpressionComparer<PersistedTask>

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
@@ -64,12 +64,6 @@ public class UpscaleTaskProcessor(
             }
             else
             {
-                // Priority 2: Standard upscale queue
-                task = taskQueue.DequeueUpscale();
-            }
-
-            if (task == null)
-            {
                 // Use a linked CTS to ensure that the "losing" waiter is cancelled and removed
                 // from its channel when one of them completes.
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
@@ -64,6 +64,12 @@ public class UpscaleTaskProcessor(
             }
             else
             {
+                // Priority 2: Standard upscale queue
+                task = taskQueue.DequeueUpscale();
+            }
+
+            if (task == null)
+            {
                 // Use a linked CTS to ensure that the "losing" waiter is cancelled and removed
                 // from its channel when one of them completes.
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
@@ -5,7 +5,6 @@ using MangaIngestWithUpscaling.Data.BackgroundTaskQueue;
 using MangaIngestWithUpscaling.Shared.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using Open.ChannelExtensions;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue;
 
@@ -19,7 +18,7 @@ public class UpscaleTaskProcessor(
 {
     private readonly Lock _lock = new();
     private readonly TimeSpan _progressDebounce = TimeSpan.FromMilliseconds(250);
-    private readonly ChannelReader<PersistedTask> _reader = taskQueue.UpscaleReader;
+    private readonly ChannelReader<object> _reader = taskQueue.UpscaleReader;
     private readonly ChannelReader<PersistedTask> _reroutedReader = taskQueue.ReroutedUpscaleReader;
     private CancellationTokenSource? currentStoppingToken;
     private PersistedTask? currentTask;
@@ -54,30 +53,47 @@ public class UpscaleTaskProcessor(
 
         serviceStoppingToken = stoppingToken;
 
-        // Merge the rerouted and regular upscale channels into a single reader using Open.ChannelExtensions
-        var merged = Channel.CreateBounded<PersistedTask>(
-            new BoundedChannelOptions(1)
-            {
-                SingleReader = true,
-                SingleWriter = false,
-                AllowSynchronousContinuations = true,
-            }
-        );
-
-        // Start piping both sources into the merged channel (will complete when sources complete)
-        _ = _reroutedReader.PipeTo(merged, stoppingToken);
-        _ = _reader.PipeTo(merged, stoppingToken);
-
         while (!stoppingToken.IsCancellationRequested)
         {
-            PersistedTask task;
-            if (_reroutedReader.TryRead(out PersistedTask? rerouted))
+            PersistedTask? task = null;
+
+            // Priority 1: Rerouted tasks (already claimed or specialized)
+            if (_reroutedReader.TryRead(out var rerouted))
             {
                 task = rerouted;
             }
             else
             {
-                task = await merged.Reader.ReadAsync(stoppingToken);
+                // Wait for either a rerouted task OR a signal from the main upscale queue
+                var reroutedWait = _reroutedReader.WaitToReadAsync(stoppingToken).AsTask();
+                var signalWait = _reader.WaitToReadAsync(stoppingToken).AsTask();
+
+                var completed = await Task.WhenAny(reroutedWait, signalWait);
+
+                if (completed == reroutedWait && await reroutedWait)
+                {
+                    if (_reroutedReader.TryRead(out var r))
+                    {
+                        task = r;
+                    }
+                }
+                else if (completed == signalWait && await signalWait)
+                {
+                    // Check rerouted one last time before consuming a signal
+                    if (_reroutedReader.TryRead(out var r))
+                    {
+                        task = r;
+                    }
+                    else if (_reader.TryRead(out _))
+                    {
+                        task = taskQueue.DequeueUpscale();
+                    }
+                }
+            }
+
+            if (task == null)
+            {
+                continue;
             }
 
             using (_lock.EnterScope())

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
@@ -64,9 +64,11 @@ public class UpscaleTaskProcessor(
             }
             else
             {
-                // Wait for either a rerouted task OR a signal from the main upscale queue
-                var reroutedWait = _reroutedReader.WaitToReadAsync(stoppingToken).AsTask();
-                var signalWait = _reader.WaitToReadAsync(stoppingToken).AsTask();
+                // Use a linked CTS to ensure that the "losing" waiter is cancelled and removed 
+                // from its channel when one of them completes.
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                var reroutedWait = _reroutedReader.WaitToReadAsync(linkedCts.Token).AsTask();
+                var signalWait = _reader.WaitToReadAsync(linkedCts.Token).AsTask();
 
                 var completed = await Task.WhenAny(reroutedWait, signalWait);
 
@@ -89,6 +91,9 @@ public class UpscaleTaskProcessor(
                         task = taskQueue.DequeueUpscale();
                     }
                 }
+
+                // Cancel the CTS to remove any abandoned waiter from the channels
+                await linkedCts.CancelAsync();
             }
 
             if (task == null)

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
@@ -117,14 +117,17 @@ public class UpscaleTaskProcessor(
 
     protected async Task ProcessTaskAsync(PersistedTask task, CancellationToken stoppingToken)
     {
-        // Atomically claim the task
-        if (!await taskPersistenceService.ClaimTaskAsync(task.Id, stoppingToken))
+        // Atomically claim the task if not already claimed (e.g. by DistributedUpscaleTaskProcessor before rerouting)
+        if (task.Status != PersistedTaskStatus.Processing)
         {
-            logger.LogInformation(
-                "Task {TaskId} could not be claimed (already processed or concurrency conflict)",
-                task.Id
-            );
-            return;
+            if (!await taskPersistenceService.ClaimTaskAsync(task.Id, stoppingToken))
+            {
+                logger.LogInformation(
+                    "Task {TaskId} could not be claimed (already processed or concurrency conflict)",
+                    task.Id
+                );
+                return;
+            }
         }
 
         // Update the in-memory task status

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/UpscaleTaskProcessor.cs
@@ -64,9 +64,11 @@ public class UpscaleTaskProcessor(
             }
             else
             {
-                // Use a linked CTS to ensure that the "losing" waiter is cancelled and removed 
+                // Use a linked CTS to ensure that the "losing" waiter is cancelled and removed
                 // from its channel when one of them completes.
-                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    stoppingToken
+                );
                 var reroutedWait = _reroutedReader.WaitToReadAsync(linkedCts.Token).AsTask();
                 var signalWait = _reader.WaitToReadAsync(linkedCts.Token).AsTask();
 

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
@@ -68,21 +68,30 @@ public class DistributedUpscaleTaskProcessorTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task GetTask_ShouldReturnTaskFromSignal()
+    public async Task GetTask_ShouldRespectPriorityChangeAfterSignal()
     {
         // Arrange
         var cts = new CancellationTokenSource();
-        // Use DetectSplitCandidatesTask as it's an upscale task but not specifically handled
-        // by the DB-check logic in DistributedUpscaleTaskProcessor.ExecuteAsync
-        var splitTask = new DetectSplitCandidatesTask(1, 1);
-        await _taskQueue.EnqueueAsync(splitTask);
+
+        // 1. Enqueue two tasks
+        await _taskQueue.EnqueueAsync(new DetectSplitCandidatesTask(1, 1));
+        await _taskQueue.EnqueueAsync(new DetectSplitCandidatesTask(2, 1));
+
+        // 2. Get tasks from snapshot and reorder
+        var tasks = _taskQueue.GetUpscaleSnapshot();
+        var task1 = tasks.First(t => ((DetectSplitCandidatesTask)t.Data).ChapterId == 1);
+        var task2 = tasks.First(t => ((DetectSplitCandidatesTask)t.Data).ChapterId == 2);
+
+        // Make task 2 higher priority
+        await _taskQueue.ReorderTaskAsync(task2, 0);
 
         // Act
         var runTask = _processor.StartAsync(cts.Token);
 
-        // GetTask will write to _taskRequests, which ExecuteAsync will pick up,
-        // then it will wait for signal on upscale queue, then dequeue.
-        var taskResult = await _processor.GetTask(cts.Token);
+        // First worker request should get high priority task (task 2)
+        var result1 = await _processor.GetTask(cts.Token);
+        // Second worker request should get low priority task (task 1)
+        var result2 = await _processor.GetTask(cts.Token);
 
         await cts.CancelAsync();
         try
@@ -92,7 +101,9 @@ public class DistributedUpscaleTaskProcessorTests : IDisposable
         catch (OperationCanceledException) { }
 
         // Assert
-        Assert.NotNull(taskResult);
-        Assert.IsType<DetectSplitCandidatesTask>(taskResult.Data);
+        Assert.NotNull(result1);
+        Assert.NotNull(result2);
+        Assert.Equal(2, ((DetectSplitCandidatesTask)result1.Data).ChapterId);
+        Assert.Equal(1, ((DetectSplitCandidatesTask)result2.Data).ChapterId);
     }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
@@ -1,0 +1,98 @@
+using MangaIngestWithUpscaling.Data;
+using MangaIngestWithUpscaling.Data.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Services.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
+using MangaIngestWithUpscaling.Shared.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace MangaIngestWithUpscaling.Tests.Services.BackgroundTaskQueue;
+
+public class DistributedUpscaleTaskProcessorTests : IDisposable
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly ITaskPersistenceService _mockPersistence;
+    private readonly IOptions<UpscalerConfig> _mockOptions;
+    private readonly IServiceScope _scope;
+    private readonly TaskQueue _taskQueue;
+    private readonly DistributedUpscaleTaskProcessor _processor;
+
+    public DistributedUpscaleTaskProcessorTests()
+    {
+        var services = new ServiceCollection();
+        var dbName = $"TestDb_DistributedProcessor_{Guid.NewGuid()}";
+        services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(dbName));
+
+        _mockPersistence = Substitute.For<ITaskPersistenceService>();
+        _mockPersistence.ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        _mockOptions = Substitute.For<IOptions<UpscalerConfig>>();
+        _mockOptions.Value.Returns(new UpscalerConfig { RemoteOnly = true });
+
+        var mockQueueCleanup = Substitute.For<IQueueCleanup>();
+        mockQueueCleanup
+            .CleanupAsync()
+            .Returns(Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>()));
+        services.AddScoped<IQueueCleanup>(_ => mockQueueCleanup);
+
+        var mockLogger = Substitute.For<ILogger<DistributedUpscaleTaskProcessor>>();
+        services.AddSingleton(mockLogger);
+        services.AddSingleton(_mockPersistence);
+
+        var serviceProvider = services.BuildServiceProvider();
+        _scope = serviceProvider.CreateScope();
+        _dbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var queueLogger = Substitute.For<ILogger<TaskQueue>>();
+
+        _taskQueue = new TaskQueue(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            queueLogger
+        );
+
+        _processor = new DistributedUpscaleTaskProcessor(
+            _taskQueue,
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            _mockOptions,
+            _mockPersistence
+        );
+    }
+
+    public void Dispose()
+    {
+        _scope.Dispose();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetTask_ShouldReturnTaskFromSignal()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        // Use DetectSplitCandidatesTask as it's an upscale task but not specifically handled
+        // by the DB-check logic in DistributedUpscaleTaskProcessor.ExecuteAsync
+        var splitTask = new DetectSplitCandidatesTask(1, 1);
+        await _taskQueue.EnqueueAsync(splitTask);
+
+        // Act
+        var runTask = _processor.StartAsync(cts.Token);
+
+        // GetTask will write to _taskRequests, which ExecuteAsync will pick up,
+        // then it will wait for signal on upscale queue, then dequeue.
+        var taskResult = await _processor.GetTask(cts.Token);
+
+        await cts.CancelAsync();
+        try
+        {
+            await runTask;
+        }
+        catch (OperationCanceledException) { }
+
+        // Assert
+        Assert.NotNull(taskResult);
+        Assert.IsType<DetectSplitCandidatesTask>(taskResult.Data);
+    }
+}

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/StandardTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/StandardTaskProcessorTests.cs
@@ -61,34 +61,50 @@ public class StandardTaskProcessorTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ExecuteAsync_ShouldProcessTaskFromSignal()
+    public async Task ExecuteAsync_ShouldRespectPriorityChangeAfterSignal()
     {
         // Arrange
         var cts = new CancellationTokenSource();
-        var logTask = new LoggingTask { Message = "standard test" };
-        await _taskQueue.EnqueueAsync(logTask);
 
-        var tcs = new TaskCompletionSource<PersistedTask>();
+        // 1. Enqueue two tasks
+        await _taskQueue.EnqueueAsync(new LoggingTask { Message = "low" });
+        await _taskQueue.EnqueueAsync(new LoggingTask { Message = "high" });
+
+        // 2. Get the tasks from the snapshot and reorder them
+        var tasks = _taskQueue.GetStandardSnapshot();
+        var lowTask = tasks.First(t => ((LoggingTask)t.Data).Message == "low");
+        var highTask = tasks.First(t => ((LoggingTask)t.Data).Message == "high");
+
+        // Make "high" priority 0 (higher than "low" which is likely 1)
+        await _taskQueue.ReorderTaskAsync(highTask, 0);
+
+        var processedTasks = new List<PersistedTask>();
+        var tcs = new TaskCompletionSource();
+
         _processor.StatusChanged += (task) =>
         {
             if (task.Status == PersistedTaskStatus.Processing)
             {
-                tcs.TrySetResult(task);
+                processedTasks.Add(task);
+                if (processedTasks.Count == 2)
+                {
+                    tcs.TrySetResult();
+                }
             }
             return Task.CompletedTask;
         };
 
-        // Act
+        // 3. Start processor
         var runTask = _processor.StartAsync(cts.Token);
-        var processed = await tcs.Task.WaitAsync(
-            TimeSpan.FromSeconds(5),
-            TestContext.Current.CancellationToken
-        );
+
+        // 4. Wait for processing to complete
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await cts.CancelAsync();
         await runTask;
 
         // Assert
-        Assert.NotNull(processed);
-        Assert.Equal("standard test", ((LoggingTask)processed.Data).Message);
+        Assert.Equal(2, processedTasks.Count);
+        Assert.Equal("high", ((LoggingTask)processedTasks[0].Data).Message);
+        Assert.Equal("low", ((LoggingTask)processedTasks[1].Data).Message);
     }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/StandardTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/StandardTaskProcessorTests.cs
@@ -1,0 +1,94 @@
+using MangaIngestWithUpscaling.Data;
+using MangaIngestWithUpscaling.Data.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Services.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace MangaIngestWithUpscaling.Tests.Services.BackgroundTaskQueue;
+
+public class StandardTaskProcessorTests : IDisposable
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly ILogger<StandardTaskProcessor> _mockLogger;
+    private readonly ITaskPersistenceService _mockPersistence;
+    private readonly IServiceScope _scope;
+    private readonly TaskQueue _taskQueue;
+    private readonly StandardTaskProcessor _processor;
+
+    public StandardTaskProcessorTests()
+    {
+        var services = new ServiceCollection();
+        var dbName = $"TestDb_StandardProcessor_{Guid.NewGuid()}";
+        services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(dbName));
+
+        _mockPersistence = Substitute.For<ITaskPersistenceService>();
+        _mockPersistence.ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var mockQueueCleanup = Substitute.For<IQueueCleanup>();
+        mockQueueCleanup
+            .CleanupAsync()
+            .Returns(Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>()));
+        services.AddScoped<IQueueCleanup>(_ => mockQueueCleanup);
+        services.AddSingleton(_mockPersistence);
+
+        var serviceProvider = services.BuildServiceProvider();
+        _scope = serviceProvider.CreateScope();
+        _dbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        _mockLogger = Substitute.For<ILogger<StandardTaskProcessor>>();
+        var queueLogger = Substitute.For<ILogger<TaskQueue>>();
+
+        _taskQueue = new TaskQueue(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            queueLogger
+        );
+
+        _processor = new StandardTaskProcessor(
+            _taskQueue,
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            _mockLogger,
+            _mockPersistence
+        );
+    }
+
+    public void Dispose()
+    {
+        _scope.Dispose();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ExecuteAsync_ShouldProcessTaskFromSignal()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var logTask = new LoggingTask { Message = "standard test" };
+        await _taskQueue.EnqueueAsync(logTask);
+
+        var tcs = new TaskCompletionSource<PersistedTask>();
+        _processor.StatusChanged += (task) =>
+        {
+            if (task.Status == PersistedTaskStatus.Processing)
+            {
+                tcs.TrySetResult(task);
+            }
+            return Task.CompletedTask;
+        };
+
+        // Act
+        var runTask = _processor.StartAsync(cts.Token);
+        var processed = await tcs.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken
+        );
+        await cts.CancelAsync();
+        await runTask;
+
+        // Assert
+        Assert.NotNull(processed);
+        Assert.Equal("standard test", ((LoggingTask)processed.Data).Message);
+    }
+}

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -333,7 +333,7 @@ public class TaskQueueTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReplayPendingOrFailed_WithMultiplePendingTasks_ShouldSignalAll()
+    public async Task ReplayPendingOrFailed_WithMultiplePendingTasks_ShouldSignalOnce()
     {
         // Arrange
         var tasks = new[]
@@ -360,43 +360,49 @@ public class TaskQueueTests : IDisposable
         await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.True(_taskQueue.StandardReader.TryRead(out _), "First signal should be present");
-        Assert.True(_taskQueue.StandardReader.TryRead(out _), "Second signal should be present");
+        Assert.True(_taskQueue.StandardReader.TryRead(out _), "Signal should be present");
         Assert.False(
             _taskQueue.StandardReader.TryRead(out _),
-            "Third signal should NOT be present"
+            "Only one coalesced signal should be present even for multiple tasks"
         );
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReplayPendingOrFailed_WithFailedTasks_ShouldRaiseEnqueuedOrChanged()
+    public async Task RetryAsync_ShouldEmitSignal()
     {
         // Arrange
-        var failedTask = new PersistedTask
+        var task = new PersistedTask
         {
-            Id = 201,
+            Id = 301,
             Order = 1,
             Status = PersistedTaskStatus.Failed,
-            Data = new LoggingTask { Message = "failed-ui", RetryFor = 1 },
+            Data = new LoggingTask { Message = "retry-signal" },
         };
-        _dbContext.PersistedTasks.Add(failedTask);
+        _dbContext.PersistedTasks.Add(task);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        bool notified = false;
-        _taskQueue.TaskEnqueuedOrChanged += task =>
-        {
-            if (task.Id == 201 && task.Status == PersistedTaskStatus.Pending)
-            {
-                notified = true;
-            }
-            return Task.CompletedTask;
-        };
-
         // Act
-        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
+        await _taskQueue.RetryAsync(task);
 
         // Assert
-        Assert.True(notified, "UI should be notified of status change from Failed to Pending");
+        Assert.True(
+            _taskQueue.StandardReader.TryRead(out _),
+            "RetryAsync should emit a signal for standard tasks"
+        );
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DequeueStandard_WhenEmptyWithStaleSignal_ShouldReturnNull()
+    {
+        // Arrange - Enqueue and then remove to leave a stale signal
+        await _taskQueue.EnqueueAsync(new LoggingTask { Message = "stale" });
+        var task = _taskQueue.GetStandardSnapshot().First();
+        await _taskQueue.RemoveTaskAsync(task);
+
+        // Assert
+        Assert.True(_taskQueue.StandardReader.TryRead(out _), "Stale signal should be present");
+        Assert.Null(_taskQueue.DequeueStandard());
     }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -231,7 +231,7 @@ public class TaskQueueTests : IDisposable
         // Arrange
         await _taskQueue.EnqueueAsync(new LoggingTask { Message = "task2" }); // Order 1
         await _taskQueue.EnqueueAsync(new LoggingTask { Message = "task1" }); // Order 2
-        
+
         var snapshot = _taskQueue.GetStandardSnapshot();
         var task1 = snapshot.First(t => ((LoggingTask)t.Data).Message == "task1");
         var task2 = snapshot.First(t => ((LoggingTask)t.Data).Message == "task2");
@@ -304,13 +304,15 @@ public class TaskQueueTests : IDisposable
     public async Task ReplayPendingOrFailed_ShouldEmitSignalsOnlyForNewTasks()
     {
         // Arrange
-        _dbContext.PersistedTasks.Add(new PersistedTask 
-        { 
-            Id = 10, 
-            Order = 1, 
-            Status = PersistedTaskStatus.Pending, 
-            Data = new LoggingTask { Message = "replay" } 
-        });
+        _dbContext.PersistedTasks.Add(
+            new PersistedTask
+            {
+                Id = 10,
+                Order = 1,
+                Status = PersistedTaskStatus.Pending,
+                Data = new LoggingTask { Message = "replay" },
+            }
+        );
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // First replay - should add task and emit signal

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -62,7 +62,7 @@ public class TaskQueueTests : IDisposable
 
         // Act & Assert
         Exception? exception = await Record.ExceptionAsync(() =>
-            _taskQueue.SendToLocalUpscaleAsync(task, CancellationToken.None).AsTask()
+            _taskQueue.SendToLocalUpscaleAsync(task, TestContext.Current.CancellationToken).AsTask()
         );
         Assert.Null(exception);
     }
@@ -102,7 +102,7 @@ public class TaskQueueTests : IDisposable
     {
         // Act & Assert - This method handles database operations, should not throw
         Exception? exception = await Record.ExceptionAsync(() =>
-            _taskQueue.ReplayPendingOrFailed(CancellationToken.None)
+            _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken)
         );
         Assert.Null(exception);
     }
@@ -157,7 +157,7 @@ public class TaskQueueTests : IDisposable
     {
         // Act & Assert - StartAsync calls ReplayPendingOrFailed and should complete
         Exception? exception = await Record.ExceptionAsync(() =>
-            _taskQueue.StartAsync(CancellationToken.None)
+            _taskQueue.StartAsync(TestContext.Current.CancellationToken)
         );
         Assert.Null(exception);
     }
@@ -207,5 +207,118 @@ public class TaskQueueTests : IDisposable
 
         // Act & Assert - Should throw exception when trying to update non-existent entity
         await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => _taskQueue.RetryAsync(task));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldEmitSignal()
+    {
+        // Arrange
+        var logTask = new LoggingTask { Message = "test" };
+
+        // Act
+        await _taskQueue.EnqueueAsync(logTask);
+
+        // Assert
+        bool hasSignal = _taskQueue.StandardReader.TryRead(out _);
+        Assert.True(hasSignal);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DequeueStandard_ShouldReturnHighestPriorityTask()
+    {
+        // Arrange
+        await _taskQueue.EnqueueAsync(new LoggingTask { Message = "task2" }); // Order 1
+        await _taskQueue.EnqueueAsync(new LoggingTask { Message = "task1" }); // Order 2
+        
+        var snapshot = _taskQueue.GetStandardSnapshot();
+        var task1 = snapshot.First(t => ((LoggingTask)t.Data).Message == "task1");
+        var task2 = snapshot.First(t => ((LoggingTask)t.Data).Message == "task2");
+
+        // Force task1 to have higher priority (lower order)
+        await _taskQueue.ReorderTaskAsync(task1, 0);
+
+        // Act
+        var dequeued = _taskQueue.DequeueStandard();
+
+        // Assert
+        Assert.NotNull(dequeued);
+        Assert.Equal("task1", ((LoggingTask)dequeued.Data).Message);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_DetectSplitCandidatesTask_ShouldRouteToUpscale()
+    {
+        // Arrange
+        var splitTask = new DetectSplitCandidatesTask(1, 1);
+
+        // Act
+        await _taskQueue.EnqueueAsync(splitTask);
+
+        // Assert
+        Assert.Single(_taskQueue.GetUpscaleSnapshot());
+        Assert.Empty(_taskQueue.GetStandardSnapshot());
+        Assert.True(_taskQueue.UpscaleReader.TryRead(out _));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReorderTaskAsync_DetectSplitCandidatesTask_ShouldUpdateUpscaleSet()
+    {
+        // Arrange
+        var splitTaskData = new DetectSplitCandidatesTask(1, 1);
+        await _taskQueue.EnqueueAsync(splitTaskData);
+        var task = _taskQueue.GetUpscaleSnapshot().First();
+
+        // Act
+        await _taskQueue.ReorderTaskAsync(task, -10);
+
+        // Assert
+        var dequeued = _taskQueue.DequeueUpscale();
+        Assert.NotNull(dequeued);
+        Assert.Equal(-10, dequeued.Order);
+        Assert.IsType<DetectSplitCandidatesTask>(dequeued.Data);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RemoveTaskAsync_ApplySplitsTask_ShouldRemoveFromUpscaleSet()
+    {
+        // Arrange
+        var splitTaskData = new ApplySplitsTask(1, 1);
+        await _taskQueue.EnqueueAsync(splitTaskData);
+        var task = _taskQueue.GetUpscaleSnapshot().First();
+
+        // Act
+        await _taskQueue.RemoveTaskAsync(task);
+
+        // Assert
+        Assert.Empty(_taskQueue.GetUpscaleSnapshot());
+        Assert.Null(_taskQueue.DequeueUpscale());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReplayPendingOrFailed_ShouldEmitSignalsOnlyForNewTasks()
+    {
+        // Arrange
+        _dbContext.PersistedTasks.Add(new PersistedTask 
+        { 
+            Id = 10, 
+            Order = 1, 
+            Status = PersistedTaskStatus.Pending, 
+            Data = new LoggingTask { Message = "replay" } 
+        });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // First replay - should add task and emit signal
+        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
+        Assert.True(_taskQueue.StandardReader.TryRead(out _));
+
+        // Second replay - task already in SortedSet, should NOT emit signal
+        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
+        Assert.False(_taskQueue.StandardReader.TryRead(out _));
     }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -333,7 +333,7 @@ public class TaskQueueTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReplayPendingOrFailed_WithMultiplePendingTasks_ShouldSignalOnce()
+    public async Task ReplayPendingOrFailed_WithMultiplePendingTasks_ShouldSignalAll()
     {
         // Arrange
         var tasks = new[]
@@ -360,10 +360,11 @@ public class TaskQueueTests : IDisposable
         await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.True(_taskQueue.StandardReader.TryRead(out _), "Signal should be present");
+        Assert.True(_taskQueue.StandardReader.TryRead(out _), "First signal should be present");
+        Assert.True(_taskQueue.StandardReader.TryRead(out _), "Second signal should be present");
         Assert.False(
             _taskQueue.StandardReader.TryRead(out _),
-            "Only one coalesced signal should be present even for multiple tasks"
+            "Third signal should NOT be present"
         );
     }
 

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -301,26 +301,33 @@ public class TaskQueueTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReplayPendingOrFailed_ShouldEmitSignalsOnlyForNewTasks()
+    public async Task ReplayPendingOrFailed_WithFailedTasks_ShouldResetToPending()
     {
         // Arrange
-        _dbContext.PersistedTasks.Add(
-            new PersistedTask
-            {
-                Id = 10,
-                Order = 1,
-                Status = PersistedTaskStatus.Pending,
-                Data = new LoggingTask { Message = "replay" },
-            }
-        );
+        var failedTask = new PersistedTask
+        {
+            Id = 11,
+            Order = 1,
+            Status = PersistedTaskStatus.Failed,
+            RetryCount = 0,
+            Data = new LoggingTask { Message = "failed", RetryFor = 1 },
+        };
+        _dbContext.PersistedTasks.Add(failedTask);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // First replay - should add task and emit signal
+        // Act
         await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
-        Assert.True(_taskQueue.StandardReader.TryRead(out _));
 
-        // Second replay - task already in SortedSet, should NOT emit signal
-        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
-        Assert.False(_taskQueue.StandardReader.TryRead(out _));
+        // Assert
+        // Use a separate scope to verify DB changes
+        using var checkScope = _scope.ServiceProvider.CreateScope();
+        var checkDb = checkScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var reloaded = await checkDb
+            .PersistedTasks.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == 11, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(reloaded);
+        Assert.Equal(PersistedTaskStatus.Pending, reloaded.Status);
+        Assert.True(_taskQueue.StandardReader.TryRead(out _));
     }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -330,4 +330,73 @@ public class TaskQueueTests : IDisposable
         Assert.Equal(PersistedTaskStatus.Pending, reloaded.Status);
         Assert.True(_taskQueue.StandardReader.TryRead(out _));
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReplayPendingOrFailed_WithMultiplePendingTasks_ShouldSignalAll()
+    {
+        // Arrange
+        var tasks = new[]
+        {
+            new PersistedTask
+            {
+                Id = 101,
+                Order = 1,
+                Status = PersistedTaskStatus.Pending,
+                Data = new LoggingTask { Message = "1" },
+            },
+            new PersistedTask
+            {
+                Id = 102,
+                Order = 2,
+                Status = PersistedTaskStatus.Pending,
+                Data = new LoggingTask { Message = "2" },
+            },
+        };
+        _dbContext.PersistedTasks.AddRange(tasks);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(_taskQueue.StandardReader.TryRead(out _), "First signal should be present");
+        Assert.True(_taskQueue.StandardReader.TryRead(out _), "Second signal should be present");
+        Assert.False(
+            _taskQueue.StandardReader.TryRead(out _),
+            "Third signal should NOT be present"
+        );
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReplayPendingOrFailed_WithFailedTasks_ShouldRaiseEnqueuedOrChanged()
+    {
+        // Arrange
+        var failedTask = new PersistedTask
+        {
+            Id = 201,
+            Order = 1,
+            Status = PersistedTaskStatus.Failed,
+            Data = new LoggingTask { Message = "failed-ui", RetryFor = 1 },
+        };
+        _dbContext.PersistedTasks.Add(failedTask);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        bool notified = false;
+        _taskQueue.TaskEnqueuedOrChanged += task =>
+        {
+            if (task.Id == 201 && task.Status == PersistedTaskStatus.Pending)
+            {
+                notified = true;
+            }
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(notified, "UI should be notified of status change from Failed to Pending");
+    }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
@@ -28,7 +28,17 @@ public class UpscaleTaskProcessorTests : IDisposable
         services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(dbName));
 
         _mockPersistence = Substitute.For<ITaskPersistenceService>();
-        _mockPersistence.ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(true);
+        // Simulate production: claiming only succeeds if the task is Pending.
+        // Rerouted tasks are already 'Processing' when they reach UpscaleTaskProcessor.
+        _mockPersistence
+            .ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(x =>
+            {
+                var taskId = (int)x[0];
+                // In production this would check the DB.
+                // We'll trust the logic in ProcessTaskAsync to only call this for non-Processing tasks.
+                return true;
+            });
 
         _mockOptions = Substitute.For<IOptions<UpscalerConfig>>();
         _mockOptions.Value.Returns(new UpscalerConfig { RemoteOnly = false });
@@ -85,7 +95,7 @@ public class UpscaleTaskProcessorTests : IDisposable
         {
             Id = 2,
             Order = 100, // Much lower priority by order
-            Status = PersistedTaskStatus.Pending,
+            Status = PersistedTaskStatus.Processing, // Mark as already claimed
             Data = new RepairUpscaleTask { ChapterId = 1, UpscalerProfileId = 1 },
         };
 

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
@@ -1,0 +1,148 @@
+using MangaIngestWithUpscaling.Data;
+using MangaIngestWithUpscaling.Data.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Services.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
+using MangaIngestWithUpscaling.Shared.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace MangaIngestWithUpscaling.Tests.Services.BackgroundTaskQueue;
+
+public class UpscaleTaskProcessorTests : IDisposable
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly ILogger<UpscaleTaskProcessor> _mockLogger;
+    private readonly ITaskPersistenceService _mockPersistence;
+    private readonly IOptions<UpscalerConfig> _mockOptions;
+    private readonly IServiceScope _scope;
+    private readonly TaskQueue _taskQueue;
+    private readonly UpscaleTaskProcessor _processor;
+
+    public UpscaleTaskProcessorTests()
+    {
+        var services = new ServiceCollection();
+        var dbName = $"TestDb_Processor_{Guid.NewGuid()}";
+        services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(dbName));
+        
+        _mockPersistence = Substitute.For<ITaskPersistenceService>();
+        _mockPersistence.ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        _mockOptions = Substitute.For<IOptions<UpscalerConfig>>();
+        _mockOptions.Value.Returns(new UpscalerConfig { RemoteOnly = false });
+
+        var mockQueueCleanup = Substitute.For<IQueueCleanup>();
+        mockQueueCleanup.CleanupAsync().Returns(Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>()));
+        services.AddScoped<IQueueCleanup>(_ => mockQueueCleanup);
+        services.AddSingleton(_mockPersistence);
+
+        var serviceProvider = services.BuildServiceProvider();
+        _scope = serviceProvider.CreateScope();
+        _dbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        
+        _mockLogger = Substitute.For<ILogger<UpscaleTaskProcessor>>();
+        var queueLogger = Substitute.For<ILogger<TaskQueue>>();
+
+        _taskQueue = new TaskQueue(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            queueLogger
+        );
+
+        _processor = new UpscaleTaskProcessor(
+            _taskQueue,
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            _mockOptions,
+            _mockLogger,
+            _mockPersistence
+        );
+    }
+
+    public void Dispose()
+    {
+        _scope.Dispose();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ExecuteAsync_ShouldPrioritizeReroutedTasksOverSignals()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        
+        var upscaleTask = new PersistedTask
+        {
+            Id = 1,
+            Order = 10,
+            Status = PersistedTaskStatus.Pending,
+            Data = new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 }
+        };
+        
+        var reroutedTask = new PersistedTask
+        {
+            Id = 2,
+            Order = 100, // Much lower priority by order
+            Status = PersistedTaskStatus.Pending,
+            Data = new RepairUpscaleTask { ChapterId = 1, UpscalerProfileId = 1 }
+        };
+
+        // Enqueue upscale task (will emit signal)
+        await _taskQueue.EnqueueAsync((UpscaleTask)upscaleTask.Data);
+        // Send rerouted task
+        await _taskQueue.SendToLocalUpscaleAsync(reroutedTask, cts.Token);
+
+        PersistedTask? firstProcessed = null;
+        var tcs = new TaskCompletionSource();
+
+        _processor.StatusChanged += (task) =>
+        {
+            if (task.Status == PersistedTaskStatus.Processing && firstProcessed == null)
+            {
+                firstProcessed = task;
+                tcs.TrySetResult();
+            }
+            return Task.CompletedTask;
+        };
+
+        // Act
+        var runTask = _processor.StartAsync(cts.Token);
+
+        // Wait for first task to be processed
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+        cts.Cancel();
+
+        // Assert
+        Assert.NotNull(firstProcessed);
+        Assert.Equal(reroutedTask.Id, firstProcessed.Id); // Rerouted should come first regardless of order
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ExecuteAsync_ShouldProcessMainQueueWhenNoReroutedTasks()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var upscaleTask = new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 };
+        await _taskQueue.EnqueueAsync(upscaleTask);
+        
+        var tcs = new TaskCompletionSource<PersistedTask>();
+        _processor.StatusChanged += (task) =>
+        {
+            if (task.Status == PersistedTaskStatus.Processing)
+            {
+                tcs.TrySetResult(task);
+            }
+            return Task.CompletedTask;
+        };
+
+        // Act
+        var runTask = _processor.StartAsync(cts.Token);
+        var processed = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+        cts.Cancel();
+
+        // Assert
+        Assert.NotNull(processed);
+        Assert.IsType<UpscaleTask>(processed.Data);
+    }
+}

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
@@ -26,7 +26,7 @@ public class UpscaleTaskProcessorTests : IDisposable
         var services = new ServiceCollection();
         var dbName = $"TestDb_Processor_{Guid.NewGuid()}";
         services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(dbName));
-        
+
         _mockPersistence = Substitute.For<ITaskPersistenceService>();
         _mockPersistence.ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(true);
 
@@ -34,14 +34,16 @@ public class UpscaleTaskProcessorTests : IDisposable
         _mockOptions.Value.Returns(new UpscalerConfig { RemoteOnly = false });
 
         var mockQueueCleanup = Substitute.For<IQueueCleanup>();
-        mockQueueCleanup.CleanupAsync().Returns(Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>()));
+        mockQueueCleanup
+            .CleanupAsync()
+            .Returns(Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>()));
         services.AddScoped<IQueueCleanup>(_ => mockQueueCleanup);
         services.AddSingleton(_mockPersistence);
 
         var serviceProvider = services.BuildServiceProvider();
         _scope = serviceProvider.CreateScope();
         _dbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        
+
         _mockLogger = Substitute.For<ILogger<UpscaleTaskProcessor>>();
         var queueLogger = Substitute.For<ILogger<TaskQueue>>();
 
@@ -70,21 +72,21 @@ public class UpscaleTaskProcessorTests : IDisposable
     {
         // Arrange
         var cts = new CancellationTokenSource();
-        
+
         var upscaleTask = new PersistedTask
         {
             Id = 1,
             Order = 10,
             Status = PersistedTaskStatus.Pending,
-            Data = new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 }
+            Data = new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 },
         };
-        
+
         var reroutedTask = new PersistedTask
         {
             Id = 2,
             Order = 100, // Much lower priority by order
             Status = PersistedTaskStatus.Pending,
-            Data = new RepairUpscaleTask { ChapterId = 1, UpscalerProfileId = 1 }
+            Data = new RepairUpscaleTask { ChapterId = 1, UpscalerProfileId = 1 },
         };
 
         // Enqueue upscale task (will emit signal)
@@ -125,7 +127,7 @@ public class UpscaleTaskProcessorTests : IDisposable
         var cts = new CancellationTokenSource();
         var upscaleTask = new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 };
         await _taskQueue.EnqueueAsync(upscaleTask);
-        
+
         var tcs = new TaskCompletionSource<PersistedTask>();
         _processor.StatusChanged += (task) =>
         {

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
@@ -28,15 +28,25 @@ public class UpscaleTaskProcessorTests : IDisposable
         services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(dbName));
 
         _mockPersistence = Substitute.For<ITaskPersistenceService>();
-        // Simulate production: claiming only succeeds if the task is Pending.
-        // Rerouted tasks are already 'Processing' when they reach UpscaleTaskProcessor.
+        // Simulate production: claiming only succeeds if the task is Pending in the database.
         _mockPersistence
             .ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(x =>
+            .Returns(async x =>
             {
                 var taskId = (int)x[0];
-                // In production this would check the DB.
-                // We'll trust the logic in ProcessTaskAsync to only call this for non-Processing tasks.
+                var task = await _dbContext.PersistedTasks.FindAsync(taskId);
+                if (task == null)
+                {
+                    return false;
+                }
+
+                if (task.Status != PersistedTaskStatus.Pending)
+                {
+                    return false;
+                }
+                // Simulate claim by updating status
+                task.Status = PersistedTaskStatus.Processing;
+                await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
                 return true;
             });
 

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
@@ -28,6 +28,21 @@ public class UpscaleTaskProcessorTests : IDisposable
         services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(dbName));
 
         _mockPersistence = Substitute.For<ITaskPersistenceService>();
+        _mockOptions = Substitute.For<IOptions<UpscalerConfig>>();
+        _mockOptions.Value.Returns(new UpscalerConfig { RemoteOnly = false });
+
+        var mockQueueCleanup = Substitute.For<IQueueCleanup>();
+        mockQueueCleanup
+            .CleanupAsync()
+            .Returns(Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>()));
+
+        services.AddScoped<IQueueCleanup>(_ => mockQueueCleanup);
+        services.AddSingleton(_mockPersistence);
+
+        var serviceProvider = services.BuildServiceProvider();
+        _scope = serviceProvider.CreateScope();
+        _dbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
         // Simulate production: claiming only succeeds if the task is Pending in the database.
         _mockPersistence
             .ClaimTaskAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -49,20 +64,6 @@ public class UpscaleTaskProcessorTests : IDisposable
                 await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
                 return true;
             });
-
-        _mockOptions = Substitute.For<IOptions<UpscalerConfig>>();
-        _mockOptions.Value.Returns(new UpscalerConfig { RemoteOnly = false });
-
-        var mockQueueCleanup = Substitute.For<IQueueCleanup>();
-        mockQueueCleanup
-            .CleanupAsync()
-            .Returns(Task.FromResult<IReadOnlyList<int>>(Array.Empty<int>()));
-        services.AddScoped<IQueueCleanup>(_ => mockQueueCleanup);
-        services.AddSingleton(_mockPersistence);
-
-        var serviceProvider = services.BuildServiceProvider();
-        _scope = serviceProvider.CreateScope();
-        _dbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         _mockLogger = Substitute.For<ILogger<UpscaleTaskProcessor>>();
         var queueLogger = Substitute.For<ILogger<TaskQueue>>();

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
@@ -111,8 +111,9 @@ public class UpscaleTaskProcessorTests : IDisposable
         var runTask = _processor.StartAsync(cts.Token);
 
         // Wait for first task to be processed
-        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
-        cts.Cancel();
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await cts.CancelAsync();
+        await runTask;
 
         // Assert
         Assert.NotNull(firstProcessed);
@@ -140,8 +141,12 @@ public class UpscaleTaskProcessorTests : IDisposable
 
         // Act
         var runTask = _processor.StartAsync(cts.Token);
-        var processed = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
-        cts.Cancel();
+        var processed = await tcs.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken
+        );
+        await cts.CancelAsync();
+        await runTask;
 
         // Assert
         Assert.NotNull(processed);

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/UpscaleTaskProcessorTests.cs
@@ -83,25 +83,26 @@ public class UpscaleTaskProcessorTests : IDisposable
         // Arrange
         var cts = new CancellationTokenSource();
 
-        var upscaleTask = new PersistedTask
-        {
-            Id = 1,
-            Order = 10,
-            Status = PersistedTaskStatus.Pending,
-            Data = new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 },
-        };
+        // 1. Enqueue a normal upscale task (will stay in main queue)
+        await _taskQueue.EnqueueAsync(new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 });
 
-        var reroutedTask = new PersistedTask
-        {
-            Id = 2,
-            Order = 100, // Much lower priority by order
-            Status = PersistedTaskStatus.Processing, // Mark as already claimed
-            Data = new RepairUpscaleTask { ChapterId = 1, UpscalerProfileId = 1 },
-        };
+        // 2. Enqueue another task that we will simulate as being "rerouted"
+        await _taskQueue.EnqueueAsync(
+            new RepairUpscaleTask { ChapterId = 1, UpscalerProfileId = 1 }
+        );
 
-        // Enqueue upscale task (will emit signal)
-        await _taskQueue.EnqueueAsync((UpscaleTask)upscaleTask.Data);
-        // Send rerouted task
+        // Get the tasks from the DB to make them "real"
+        var tasks = await _dbContext
+            .PersistedTasks.OrderBy(t => t.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        var upscaleTask = tasks[0];
+        var reroutedTask = tasks[1];
+
+        // Simulate DistributedUpscaleTaskProcessor behavior:
+        // Mark the task as Processing (already claimed) before sending it to the local processor.
+        reroutedTask.Status = PersistedTaskStatus.Processing;
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        // 3. Send rerouted task directly to the local channel
         await _taskQueue.SendToLocalUpscaleAsync(reroutedTask, cts.Token);
 
         PersistedTask? firstProcessed = null;
@@ -132,34 +133,50 @@ public class UpscaleTaskProcessorTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ExecuteAsync_ShouldProcessMainQueueWhenNoReroutedTasks()
+    public async Task ExecuteAsync_ShouldRespectPriorityChangeAfterSignal()
     {
         // Arrange
         var cts = new CancellationTokenSource();
-        var upscaleTask = new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 };
-        await _taskQueue.EnqueueAsync(upscaleTask);
 
-        var tcs = new TaskCompletionSource<PersistedTask>();
+        // 1. Enqueue two tasks
+        await _taskQueue.EnqueueAsync(new UpscaleTask { ChapterId = 1, UpscalerProfileId = 1 });
+        await _taskQueue.EnqueueAsync(new UpscaleTask { ChapterId = 2, UpscalerProfileId = 1 });
+
+        // 2. Get tasks from snapshot and reorder
+        var tasks = _taskQueue.GetUpscaleSnapshot();
+        var task1 = tasks.First(t => ((UpscaleTask)t.Data).ChapterId == 1);
+        var task2 = tasks.First(t => ((UpscaleTask)t.Data).ChapterId == 2);
+
+        // Make task 2 higher priority
+        await _taskQueue.ReorderTaskAsync(task2, 0);
+
+        var processedTasks = new List<PersistedTask>();
+        var tcs = new TaskCompletionSource();
+
         _processor.StatusChanged += (task) =>
         {
             if (task.Status == PersistedTaskStatus.Processing)
             {
-                tcs.TrySetResult(task);
+                processedTasks.Add(task);
+                if (processedTasks.Count == 2)
+                {
+                    tcs.TrySetResult();
+                }
             }
             return Task.CompletedTask;
         };
 
-        // Act
+        // 3. Start processor
         var runTask = _processor.StartAsync(cts.Token);
-        var processed = await tcs.Task.WaitAsync(
-            TimeSpan.FromSeconds(5),
-            TestContext.Current.CancellationToken
-        );
+
+        // 4. Wait for processing to complete
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await cts.CancelAsync();
         await runTask;
 
         // Assert
-        Assert.NotNull(processed);
-        Assert.IsType<UpscaleTask>(processed.Data);
+        Assert.Equal(2, processedTasks.Count);
+        Assert.Equal(2, ((UpscaleTask)processedTasks[0].Data).ChapterId);
+        Assert.Equal(1, ((UpscaleTask)processedTasks[1].Data).ChapterId);
     }
 }


### PR DESCRIPTION
Refactor TaskQueue to use signal-only channels instead of buffering tasks.
This ensures that task reordering (priority changes) takes effect
immediately when the next processor becomes free, rather than being stuck
behind tasks already buffered in the channel.

- Convert StandardReader and UpscaleReader to ChannelReader<object> (signals).
- Add DequeueStandard() and DequeueUpscale() for on-demand task retrieval.
- Update all processors to await signals and dequeue tasks with priority.
- Modified UpscaleTaskProcessor to prioritize rerouted tasks over signals.
- Removed unused ProcessChannelAsync background loop in TaskQueue.