### PR TITLE
fix: resolve DbContext concurrency in integrity checker

### DIFF
--- a/src/MangaIngestWithUpscaling/Services/LibraryIntegrity/LibraryIntegrityChecker.cs
+++ b/src/MangaIngestWithUpscaling/Services/LibraryIntegrity/LibraryIntegrityChecker.cs
@@ -169,11 +169,11 @@ public partial class LibraryIntegrityChecker(
             )
         );
 
-        IAsyncEnumerable<int> chapterIdsStream = dbContext
+        List<int> chapterIds = await dbContext
             .Chapters.AsNoTracking()
             .Where(c => c.Manga!.Library!.Id == library.Id)
             .Select(c => c.Id)
-            .AsAsyncEnumerable();
+            .ToListAsync(cancellationToken ?? CancellationToken.None);
         int anyChange = 0;
         CancellationToken ct = cancellationToken ?? CancellationToken.None;
 
@@ -184,7 +184,7 @@ public partial class LibraryIntegrityChecker(
         };
 
         await Parallel.ForEachAsync(
-            chapterIdsStream,
+            chapterIds,
             parallelOptions,
             async (chapterId, token) =>
             {
@@ -258,11 +258,11 @@ public partial class LibraryIntegrityChecker(
             new IntegrityProgress(totalChapters, current, "manga", $"Checking {manga.PrimaryTitle}")
         );
 
-        IAsyncEnumerable<int> chapterIdsStream = dbContext
+        List<int> chapterIds = await dbContext
             .Chapters.AsNoTracking()
             .Where(c => c.MangaId == manga.Id)
             .Select(c => c.Id)
-            .AsAsyncEnumerable();
+            .ToListAsync(cancellationToken ?? CancellationToken.None);
         int anyChange = 0;
         CancellationToken ct = cancellationToken ?? CancellationToken.None;
         var parallelOptions = new ParallelOptions
@@ -272,7 +272,7 @@ public partial class LibraryIntegrityChecker(
         };
 
         await Parallel.ForEachAsync(
-            chapterIdsStream,
+            chapterIds,
             parallelOptions,
             async (chapterId, token) =>
             {


### PR DESCRIPTION
## Summary

Fixes `InvalidOperationException` errors in the integrity checker caused by concurrent use of the same `DbContext` instance.

## Root Cause

`Parallel.ForEachAsync` was consuming `IAsyncEnumerable<int>` streams directly from the scoped `dbContext` instance. Since `Parallel.ForEachAsync` iterates the enumerable concurrently, this triggered multiple overlapping operations on the same `DbContext`, which is not thread-safe.

## Fix

Materialize chapter IDs into a `List<int>` via `ToListAsync()` before passing to `Parallel.ForEachAsync`. This ensures:

1. The DB query completes on the single scoped context before any parallelism starts
2. Each parallel task creates its own fresh `DbContext` via `IDbContextFactory` (which was already the existing design)

## Changes

- `LibraryIntegrityChecker.cs:172` — `CheckIntegrity(Library, ...)`: Replace `IAsyncEnumerable<int>` + `AsAsyncEnumerable()` with `List<int>` + `ToListAsync()`
- `LibraryIntegrityChecker.cs:261` — `CheckIntegrity(Manga, ...)`: Same change