### PR TITLE
chore(deps): update all NuGet dependencies

### DIFF
--- a/src/MangaIngestWithUpscaling.RemoteWorker/MangaIngestWithUpscaling.RemoteWorker.csproj
+++ b/src/MangaIngestWithUpscaling.RemoteWorker/MangaIngestWithUpscaling.RemoteWorker.csproj
@@ -23,17 +23,17 @@
     </Protobuf>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AutoRegisterInject" Version="1.4.1" />
+    <PackageReference Include="AutoRegisterInject" Version="2.0.2" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
-    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
+    <PackageReference Include="Microsoft.Build" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageReference Include="Open.ChannelExtensions" Version="9.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Velopack" Version="1.0.1" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../../submodules/MangaJaNaiConverterGui/MangaJaNaiConverterGui/backend/**">

--- a/src/MangaIngestWithUpscaling.Shared/MangaIngestWithUpscaling.Shared.csproj
+++ b/src/MangaIngestWithUpscaling.Shared/MangaIngestWithUpscaling.Shared.csproj
@@ -7,19 +7,19 @@
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoRegisterInject" Version="1.4.1" />
+    <PackageReference Include="AutoRegisterInject" Version="2.0.2" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Build" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.9" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageReference Include="Open.ChannelExtensions" Version="9.3.0" />
     <PackageReference Include="Silk.NET.OpenGL" Version="2.23.0" />
     <PackageReference Include="Silk.NET.Windowing" Version="2.23.0" />
@@ -27,62 +27,62 @@
     <!-- Platform-specific NetVips native libraries -->
     <PackageReference
       Include="NetVips.Native.win-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'win-x64'"
     />
     <PackageReference
       Include="NetVips.Native.win-x86"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'win-x86'"
     />
     <PackageReference
       Include="NetVips.Native.win-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'win-arm64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-x64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-arm"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-arm'"
     />
     <PackageReference
       Include="NetVips.Native.linux-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-arm64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-musl-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-musl-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-musl-arm64'"
     />
     <PackageReference
       Include="NetVips.Native.osx-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'osx-x64'"
     />
     <PackageReference
       Include="NetVips.Native.osx-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'osx-arm64'"
     />
     <!-- Fallback for AnyCPU builds - includes all platforms -->
     <PackageReference
       Include="NetVips.Native"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == '' OR '$(RuntimeIdentifier)' == 'any'"
     />
     <!-- Work around an issue with a critical security hole not being fixed yet -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
+++ b/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
@@ -19,33 +19,33 @@
     <Protobuf Include="protos\upscaling-dist.proto" GrpcServices="Server" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AutoRegisterInject" Version="1.4.1" />
+    <PackageReference Include="AutoRegisterInject" Version="2.0.2" />
     <PackageReference Include="DynamicData" Version="9.4.31" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
     <PackageReference Include="Humanizer" Version="3.0.10" />
     <PackageReference
       Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore"
-      Version="10.0.8"
+      Version="10.0.9"
     />
     <PackageReference
       Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"
-      Version="10.0.8"
+      Version="10.0.9"
     />
     <PackageReference
       Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"
-      Version="10.0.8"
+      Version="10.0.9"
     />
-    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
+    <PackageReference Include="Microsoft.Build" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference
       Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets"
       Version="1.23.0"
@@ -55,78 +55,78 @@
     <PackageReference Include="MudBlazor.Translations" Version="3.3.0" />
     <PackageReference Include="Open.ChannelExtensions" Version="9.3.0" />
     <PackageReference Include="PinguApps.Blazor.QRCode" Version="1.1.4" />
-    <PackageReference Include="ReactiveUI" Version="23.2.27" />
-    <PackageReference Include="ReactiveUI.Blazor" Version="23.2.27" />
+    <PackageReference Include="ReactiveUI" Version="23.2.28" />
+    <PackageReference Include="ReactiveUI.Blazor" Version="23.2.28" />
     <PackageReference
       Include="ReactiveMarbles.ObservableEvents.SourceGenerator"
       Version="1.3.1"
       PrivateAssets="all"
     />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.SQLite" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.SQLite" Version="7.0.0" />
     <PackageReference Include="NetVips" Version="3.2.0" />
     <!-- Platform-specific NetVips native libraries -->
     <PackageReference
       Include="NetVips.Native.win-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'win-x64'"
     />
     <PackageReference
       Include="NetVips.Native.win-x86"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'win-x86'"
     />
     <PackageReference
       Include="NetVips.Native.win-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'win-arm64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-x64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-arm"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-arm'"
     />
     <PackageReference
       Include="NetVips.Native.linux-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-arm64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-musl-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64'"
     />
     <PackageReference
       Include="NetVips.Native.linux-musl-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'linux-musl-arm64'"
     />
     <PackageReference
       Include="NetVips.Native.osx-x64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'osx-x64'"
     />
     <PackageReference
       Include="NetVips.Native.osx-arm64"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == 'osx-arm64'"
     />
     <!-- Fallback for AnyCPU builds - includes all platforms -->
     <PackageReference
       Include="NetVips.Native"
-      Version="8.18.2"
+      Version="8.18.3"
       Condition="'$(RuntimeIdentifier)' == '' OR '$(RuntimeIdentifier)' == 'any'"
     />
     <PackageReference
       Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
-      Version="10.0.8"
+      Version="10.0.9"
     />
   </ItemGroup>
   <ItemGroup>

--- a/src/MangaIngestWithUpscaling/Program.cs
+++ b/src/MangaIngestWithUpscaling/Program.cs
@@ -1,4 +1,3 @@
-using System.Data.SQLite;
 using System.Globalization;
 using System.Security.Claims;
 using MangaIngestWithUpscaling.Api;
@@ -67,12 +66,12 @@ string connectionString =
     builder.Configuration.GetConnectionString("DefaultConnection")
     ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 
-SQLiteConnectionStringBuilder sqliteConnectionStringBuilder = new(connectionString);
+SqliteConnectionStringBuilder sqliteConnectionStringBuilder = new(connectionString);
 
 var loggingConnectionString =
     builder.Configuration.GetConnectionString("LoggingConnection") ?? "Data Source=logs.db";
 
-var loggingConnectionReadOnlyStringBuilder = new SQLiteConnectionStringBuilder(
+var loggingConnectionReadOnlyStringBuilder = new SqliteConnectionStringBuilder(
     loggingConnectionString
 );
 var loggingConnectionReadOnlyString = loggingConnectionReadOnlyStringBuilder.ConnectionString;

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/BaseTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/BaseTask.cs
@@ -28,7 +28,6 @@ public class BaseTask
 
     [NotMapped]
     [JsonIgnore]
-    [Newtonsoft.Json.JsonIgnore]
     public ProgressInfo Progress { get; } = new();
 
     public virtual Task ProcessAsync(IServiceProvider services, CancellationToken cancellationToken)

--- a/test/MangaIngestWithUpscaling.RemoteWorker.Tests/MangaIngestWithUpscaling.RemoteWorker.Tests.csproj
+++ b/test/MangaIngestWithUpscaling.RemoteWorker.Tests/MangaIngestWithUpscaling.RemoteWorker.Tests.csproj
@@ -11,15 +11,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
+    <PackageReference Include="Microsoft.Build" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Grpc.AspNetCore.Server.ClientFactory" Version="2.80.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/MangaIngestWithUpscaling.Shared.Tests/MangaIngestWithUpscaling.Shared.Tests.csproj
+++ b/test/MangaIngestWithUpscaling.Shared.Tests/MangaIngestWithUpscaling.Shared.Tests.csproj
@@ -11,18 +11,18 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
+    <PackageReference Include="Microsoft.Build" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NetVips" Version="3.2.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
+++ b/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
@@ -13,16 +13,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.7.2" />
-    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
+    <PackageReference Include="Microsoft.Build" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageReference Include="MudBlazor" Version="9.5.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>

--- a/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
+++ b/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
@@ -12,19 +12,19 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
+    <PackageReference Include="Microsoft.Build" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
## Summary

Updates all NuGet dependencies to their latest versions across all 7 projects.

## Updated Packages

| Package | From | To |
|---|---|---|
| AutoRegisterInject | 1.4.1 | **2.0.2** |
| Serilog.Sinks.SQLite | 6.0.0 | **7.0.0** |
| Velopack | 1.0.1 | **1.2.0** |
| Microsoft.Extensions.Http.Resilience | 10.6.0 | 10.7.0 |
| Microsoft.Build* | 18.6.3 | 18.7.1 |
| ReactiveUI* | 23.2.27 | 23.2.28 |
| Serilog.Settings.Configuration | 10.0.0 | 10.0.1 |
| NetVips.Native* | 8.18.2 | 8.18.3 |
| Microsoft.AspNetCore/EFCore/Extensions* | 10.0.8 | 10.0.9 |

## Breaking Changes Fixed

- **Serilog.Sinks.SQLite v7** switched its underlying SQLite provider from `System.Data.SQLite` to `Microsoft.Data.Sqlite`. Updated `Program.cs` to use `SqliteConnectionStringBuilder` (from `Microsoft.Data.Sqlite`) instead of `SQLiteConnectionStringBuilder` (from `System.Data.SQLite`).
- Removed orphaned `[Newtonsoft.Json.JsonIgnore]` attribute in `BaseTask.cs` — `Newtonsoft.Json` was a transitive dependency that is no longer pulled in. The `[JsonIgnore]` attribute from `System.Text.Json` remains.

## Verification

- Solution builds with 0 warnings, 0 errors
- All 226 tests pass