### PR TITLE
feat: enforce natural chapter order for all upscale queue tasks

### DIFF
--- a/src/MangaIngestWithUpscaling/Components/MangaManagement/Chapters/ChapterList.razor
+++ b/src/MangaIngestWithUpscaling/Components/MangaManagement/Chapters/ChapterList.razor
@@ -233,7 +233,10 @@
 
     private async Task UpscaleSelectedChapters()
     {
-        var chaptersToUpscale = selectedChapters.Where(c => !c.Chapter.IsUpscaled).ToList();
+        var chaptersToUpscale = selectedChapters
+            .Where(c => !c.Chapter.IsUpscaled)
+            .ToList();
+
         foreach (var c in chaptersToUpscale)
         {
             await UpscaleChapter(c.Chapter);

--- a/src/MangaIngestWithUpscaling/Data/BackgroundTaskQueue/PersistedTask.cs
+++ b/src/MangaIngestWithUpscaling/Data/BackgroundTaskQueue/PersistedTask.cs
@@ -14,6 +14,12 @@ public class PersistedTask
     public int Order { get; set; }
 
     /// <summary>
+    /// Natural sort key for chapter-related tasks, derived from the chapter's file name.
+    /// When non-null, tasks are ordered by this key (using natural sort) instead of by <see cref="Order"/>.
+    /// </summary>
+    public string? ChapterSortKey { get; set; }
+
+    /// <summary>
     /// The last time the task was kept alive.
     /// Only used for network-distributed tasks.
     /// </summary>

--- a/src/MangaIngestWithUpscaling/Data/Migrations/20260622204811_AddChapterSortKeyToPersistedTask.Designer.cs
+++ b/src/MangaIngestWithUpscaling/Data/Migrations/20260622204811_AddChapterSortKeyToPersistedTask.Designer.cs
@@ -5,6 +5,7 @@ using MangaIngestWithUpscaling.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -12,9 +13,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MangaIngestWithUpscaling.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622204811_AddChapterSortKeyToPersistedTask")]
+    partial class AddChapterSortKeyToPersistedTask
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.9");

--- a/src/MangaIngestWithUpscaling/Data/Migrations/20260622204811_AddChapterSortKeyToPersistedTask.cs
+++ b/src/MangaIngestWithUpscaling/Data/Migrations/20260622204811_AddChapterSortKeyToPersistedTask.cs
@@ -14,15 +14,14 @@ namespace MangaIngestWithUpscaling.Migrations
                 name: "ChapterSortKey",
                 table: "PersistedTasks",
                 type: "TEXT",
-                nullable: true);
+                nullable: true
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "ChapterSortKey",
-                table: "PersistedTasks");
+            migrationBuilder.DropColumn(name: "ChapterSortKey", table: "PersistedTasks");
         }
     }
 }

--- a/src/MangaIngestWithUpscaling/Data/Migrations/20260622204811_AddChapterSortKeyToPersistedTask.cs
+++ b/src/MangaIngestWithUpscaling/Data/Migrations/20260622204811_AddChapterSortKeyToPersistedTask.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MangaIngestWithUpscaling.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChapterSortKeyToPersistedTask : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ChapterSortKey",
+                table: "PersistedTasks",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ChapterSortKey",
+                table: "PersistedTasks");
+        }
+    }
+}

--- a/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
+++ b/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
@@ -8,7 +8,8 @@
     <AssemblyName>$(AssemblyName.Replace(' ', '_'))</AssemblyName>
     <!-- Disable nullable attribute warnings on generated code due to tooling bugs -->
     <!-- see https://github.com/dotnet/razor/issues/7286 for more details -->
-    <NoWarn>$(NoWarn);NETSDK1206;CS8669;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>

--- a/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
+++ b/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
@@ -9,7 +9,6 @@
     <!-- Disable nullable attribute warnings on generated code due to tooling bugs -->
     <!-- see https://github.com/dotnet/razor/issues/7286 for more details -->
     <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
@@ -41,6 +40,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.7.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
+++ b/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>$(AssemblyName.Replace(' ', '_'))</AssemblyName>
     <!-- Disable nullable attribute warnings on generated code due to tooling bugs -->
     <!-- see https://github.com/dotnet/razor/issues/7286 for more details -->
-    <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;CS8669;NU1903</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -2,6 +2,7 @@ using System.Threading.Channels;
 using AutoRegisterInject;
 using MangaIngestWithUpscaling.Data;
 using MangaIngestWithUpscaling.Data.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Data.LibraryManagement;
 using MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 using Microsoft.EntityFrameworkCore;
 
@@ -40,36 +41,56 @@ public class TaskQueue : ITaskQueue, IHostedService
     private readonly SortedSet<PersistedTask> _upscaleTasks;
     private readonly object _upscaleTasksLock = new();
 
+    private static readonly Helpers.NaturalSortComparer<string> _naturalComparer = new(s => s);
+
     public TaskQueue(IServiceScopeFactory scopeFactory, ILogger<TaskQueue> logger)
     {
         _scopeFactory = scopeFactory;
         _logger = logger;
 
-        // Use unbounded channels for signals; signals do not carry tasks, but notify consumers to pull from sorted sets.
         _standardChannel = Channel.CreateUnbounded<object>();
         _upscaleChannel = Channel.CreateUnbounded<object>();
-        // Reroute channel remains carrying tasks: it's fed only by DistributedUpscaleTaskProcessor and consumed by the local UpscaleTaskProcessor
         _reroutedUpscaleChannel = Channel.CreateUnbounded<PersistedTask>();
 
-        // Initialize sorted sets with a stable comparer
-        // NOTE: SortedSet considers items equal when comparer returns 0 and will drop duplicates.
-        //       Comparing only by Order collapses many tasks into one when orders match.
-        //       Use Order, then Id as a tiebreaker to preserve all tasks with the same Order.
-        Comparer<PersistedTask> comparer = Comparer<PersistedTask>.Create(
+        Comparer<PersistedTask> standardComparer = Comparer<PersistedTask>.Create(
             (a, b) =>
             {
                 int byOrder = a.Order.CompareTo(b.Order);
                 if (byOrder != 0)
-                {
                     return byOrder;
-                }
 
-                // Id is unique per task (DB identity). This stabilizes ordering and avoids duplicate suppression.
                 return a.Id.CompareTo(b.Id);
             }
         );
-        _standardTasks = new SortedSet<PersistedTask>(comparer);
-        _upscaleTasks = new SortedSet<PersistedTask>(comparer);
+
+        Comparer<PersistedTask> upscaleComparer = Comparer<PersistedTask>.Create(
+            (a, b) =>
+            {
+                if (a.ChapterSortKey != null && b.ChapterSortKey != null)
+                {
+                    int byChapter = _naturalComparer.Compare(a.ChapterSortKey, b.ChapterSortKey);
+                    if (byChapter != 0)
+                        return byChapter;
+                }
+                else if (a.ChapterSortKey != null)
+                {
+                    return -1;
+                }
+                else if (b.ChapterSortKey != null)
+                {
+                    return 1;
+                }
+
+                int byOrder = a.Order.CompareTo(b.Order);
+                if (byOrder != 0)
+                    return byOrder;
+
+                return a.Id.CompareTo(b.Id);
+            }
+        );
+
+        _standardTasks = new SortedSet<PersistedTask>(standardComparer);
+        _upscaleTasks = new SortedSet<PersistedTask>(upscaleComparer);
     }
 
     public ChannelReader<object> StandardReader => _standardChannel.Reader;
@@ -114,9 +135,20 @@ public class TaskQueue : ITaskQueue, IHostedService
         using IServiceScope scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-        // Determine the next order value
         int maxOrder = await dbContext.PersistedTasks.MaxAsync(t => (int?)t.Order) ?? 0;
         var taskItem = new PersistedTask { Data = taskData, Order = maxOrder + 1 };
+
+        if (taskData is IChapterTask chapterTask)
+        {
+            var chapter = await dbContext
+                .Chapters.AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Id == chapterTask.ChapterId);
+
+            if (chapter != null)
+            {
+                taskItem.ChapterSortKey = chapter.FileName;
+            }
+        }
 
         await dbContext.PersistedTasks.AddAsync(taskItem);
         await dbContext.SaveChangesAsync();

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/ApplySplitsTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/ApplySplitsTask.cs
@@ -3,7 +3,7 @@ using MangaIngestWithUpscaling.Services.Analysis;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class ApplySplitsTask : BaseTask
+public class ApplySplitsTask : BaseTask, IChapterTask
 {
     public int ChapterId { get; set; }
     public int DetectorVersion { get; set; }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/DetectSplitCandidatesTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/DetectSplitCandidatesTask.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Localization;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class DetectSplitCandidatesTask : BaseTask
+public class DetectSplitCandidatesTask : BaseTask, IChapterTask
 {
     public int ChapterId { get; set; }
     public int DetectorVersion { get; set; }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/IChapterTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/IChapterTask.cs
@@ -1,0 +1,6 @@
+namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
+
+public interface IChapterTask
+{
+    int ChapterId { get; }
+}

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RenameUpscaledChaptersSeriesTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RenameUpscaledChaptersSeriesTask.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Localization;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class RenameUpscaledChaptersSeriesTask : BaseTask
+public class RenameUpscaledChaptersSeriesTask : BaseTask, IChapterTask
 {
     public RenameUpscaledChaptersSeriesTask() { }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RepairUpscaleTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RepairUpscaleTask.cs
@@ -15,7 +15,7 @@ namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 /// Task for repairing partially corrupted upscaled chapters by upscaling only missing pages
 /// and removing extra pages, then merging them back into the existing CBZ.
 /// </summary>
-public class RepairUpscaleTask : BaseTask
+public class RepairUpscaleTask : BaseTask, IChapterTask
 {
     public RepairUpscaleTask() { }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/UpscaleTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/UpscaleTask.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Localization;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class UpscaleTask : BaseTask
+public class UpscaleTask : BaseTask, IChapterTask
 {
     public UpscaleTask() { }
 

--- a/src/MangaIngestWithUpscaling/Services/ChapterMerging/ChapterMergeRevertService.cs
+++ b/src/MangaIngestWithUpscaling/Services/ChapterMerging/ChapterMergeRevertService.cs
@@ -482,7 +482,6 @@ public class ChapterMergeRevertService(
 
         foreach (Chapter partChapter in chaptersToUpscale)
         {
-            // Queue an individual upscale task for each missing part using the original chapter's profile
             var task = new UpscaleTask(partChapter, originalChapter.UpscalerProfile!);
             await taskQueue.EnqueueAsync(task);
             logger.LogInformation(

--- a/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
+++ b/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
@@ -3,7 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);NETSDK1206;CS8669;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="Bunit" />

--- a/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
+++ b/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
@@ -4,7 +4,6 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="Bunit" />
@@ -24,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="MudBlazor" Version="9.5.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>

--- a/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
+++ b/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;CS8669;NU1903</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="Bunit" />

--- a/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
+++ b/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;CS8669;NU1903</NoWarn>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
+++ b/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
@@ -4,7 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);NETSDK1206;CS8669;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
+++ b/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);NETSDK1206;CS8669</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -24,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>


### PR DESCRIPTION
Closes #407

All chapter-related tasks (`UpscaleTask`, `RepairUpscaleTask`, `DetectSplitCandidatesTask`, `ApplySplitsTask`, `RenameUpscaledChaptersSeriesTask`) now sort by natural chapter order within the in-memory queue, regardless of insertion order. If you enqueue Chapter 3, then Chapter 2, then Chapter 1, the queue will show Ch3 processing (it was dequeued first), then Ch1 pending, then Ch2 pending.

### Changes
- Add `IChapterTask` interface and implement on all chapter task types
- Add `ChapterSortKey` column to `PersistedTask` for natural sort ordering
- In `EnqueueAsync`, populate `ChapterSortKey` from the chapter's `FileName`
- Change `_upscaleTasks` SortedSet comparer to sort by `ChapterSortKey` (natural) first, falling back to `Order` → `Id`
- Add EF Core migration for the new column