### PR TITLE
Implement ordered queue insertion for chapter tasks at ingest time #407

### DIFF
--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -207,56 +207,54 @@ public class TaskQueue : ITaskQueue, IHostedService
             await dbContext.PersistedTasks.AddAsync(taskItem);
             await dbContext.SaveChangesAsync();
 
-            if (isUpscale)
+            bool added = false;
+            lock (_upscaleTasksLock)
             {
-                bool added;
-                lock (_upscaleTasksLock)
-                {
-                    if (targetOrder.HasValue)
-                    {
-                        var tasksToUpdate = _upscaleTasks
-                            .Where(t => t.Order >= targetOrder.Value)
-                            .ToList();
-                        foreach (var t in tasksToUpdate)
-                        {
-                            _upscaleTasks.Remove(t);
-                        }
-                        foreach (var t in tasksToUpdate)
-                        {
-                            t.Order += 1;
-                            _upscaleTasks.Add(t);
-                        }
-                    }
-                    added = _upscaleTasks.Add(taskItem);
-                }
-                if (added)
-                {
-                    await _upscaleChannel.Writer.WriteAsync(Signal);
-                }
-            }
-            else
-            {
-                bool added;
                 lock (_standardTasksLock)
                 {
                     if (targetOrder.HasValue)
                     {
-                        var tasksToUpdate = _standardTasks
-                            .Where(t => t.Order >= targetOrder.Value)
-                            .ToList();
-                        foreach (var t in tasksToUpdate)
+                        var upscaleToUpdate = _upscaleTasks.Where(t => t.Order >= targetOrder.Value).ToList();
+                        foreach (var t in upscaleToUpdate)
+                        {
+                            _upscaleTasks.Remove(t);
+                        }
+                        foreach (var t in upscaleToUpdate)
+                        {
+                            t.Order += 1;
+                            _upscaleTasks.Add(t);
+                        }
+
+                        var standardToUpdate = _standardTasks.Where(t => t.Order >= targetOrder.Value).ToList();
+                        foreach (var t in standardToUpdate)
                         {
                             _standardTasks.Remove(t);
                         }
-                        foreach (var t in tasksToUpdate)
+                        foreach (var t in standardToUpdate)
                         {
                             t.Order += 1;
                             _standardTasks.Add(t);
                         }
                     }
-                    added = _standardTasks.Add(taskItem);
+
+                    if (isUpscale)
+                    {
+                        added = _upscaleTasks.Add(taskItem);
+                    }
+                    else
+                    {
+                        added = _standardTasks.Add(taskItem);
+                    }
                 }
-                if (added)
+            }
+
+            if (added)
+            {
+                if (isUpscale)
+                {
+                    await _upscaleChannel.Writer.WriteAsync(Signal);
+                }
+                else
                 {
                     await _standardChannel.Writer.WriteAsync(Signal);
                 }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -127,25 +127,28 @@ public class TaskQueue : ITaskQueue, IHostedService
 
             if (newChapterId.HasValue)
             {
-                newChapter = await dbContext
-                    .Chapters.Include(c => c.Manga)
-                    .FirstOrDefaultAsync(c => c.Id == newChapterId.Value);
+                newChapter = await dbContext.Chapters.FirstOrDefaultAsync(c =>
+                    c.Id == newChapterId.Value
+                );
             }
 
             if (newChapter != null)
             {
-                var activeTasks = await dbContext
-                    .PersistedTasks.Where(t =>
-                        t.Status == PersistedTaskStatus.Pending
-                        || t.Status == PersistedTaskStatus.Processing
-                        || t.Status == PersistedTaskStatus.Failed
-                    )
-                    .OrderBy(t => t.Order)
-                    .ToListAsync();
-
-                var queueTasks = activeTasks
-                    .Where(t => IsUpscaleTask(t.Data) == isUpscale)
-                    .ToList();
+                List<PersistedTask> queueTasks;
+                if (isUpscale)
+                {
+                    lock (_upscaleTasksLock)
+                    {
+                        queueTasks = _upscaleTasks.ToList();
+                    }
+                }
+                else
+                {
+                    lock (_standardTasksLock)
+                    {
+                        queueTasks = _standardTasks.ToList();
+                    }
+                }
 
                 var activeChapterIds = queueTasks
                     .Select(t => GetChapterId(t.Data))
@@ -160,14 +163,6 @@ public class TaskQueue : ITaskQueue, IHostedService
 
                 foreach (var t in queueTasks)
                 {
-                    if (
-                        t.Status != PersistedTaskStatus.Pending
-                        && t.Status != PersistedTaskStatus.Failed
-                    )
-                    {
-                        continue;
-                    }
-
                     int? existChapterId = GetChapterId(t.Data);
                     if (
                         existChapterId.HasValue
@@ -278,11 +273,14 @@ public class TaskQueue : ITaskQueue, IHostedService
             {
                 foreach (var t in shiftedTasks)
                 {
-                    _ = TaskEnqueuedOrChanged.Invoke(t);
+                    await TaskEnqueuedOrChanged.Invoke(t);
                 }
             }
 
-            TaskEnqueuedOrChanged?.Invoke(taskItem);
+            if (TaskEnqueuedOrChanged != null)
+            {
+                await TaskEnqueuedOrChanged.Invoke(taskItem);
+            }
 
             var queueCleanup = scope.ServiceProvider.GetRequiredService<IQueueCleanup>();
             var removedTaskIds = await queueCleanup.CleanupAsync();

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -2,6 +2,8 @@ using System.Threading.Channels;
 using AutoRegisterInject;
 using MangaIngestWithUpscaling.Data;
 using MangaIngestWithUpscaling.Data.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Data.LibraryManagement;
+using MangaIngestWithUpscaling.Helpers;
 using MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 using Microsoft.EntityFrameworkCore;
 
@@ -33,6 +35,7 @@ public class TaskQueue : ITaskQueue, IHostedService
     private readonly Channel<PersistedTask> _reroutedUpscaleChannel;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly Channel<object> _standardChannel;
+    private readonly SemaphoreSlim _enqueueSemaphore = new(1, 1);
 
     private readonly SortedSet<PersistedTask> _standardTasks;
     private readonly object _standardTasksLock = new();
@@ -111,52 +114,169 @@ public class TaskQueue : ITaskQueue, IHostedService
     public async Task EnqueueAsync<T>(T taskData)
         where T : BaseTask
     {
-        using IServiceScope scope = _scopeFactory.CreateScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-
-        // Determine the next order value
-        int maxOrder = await dbContext.PersistedTasks.MaxAsync(t => (int?)t.Order) ?? 0;
-        var taskItem = new PersistedTask { Data = taskData, Order = maxOrder + 1 };
-
-        await dbContext.PersistedTasks.AddAsync(taskItem);
-        await dbContext.SaveChangesAsync();
-
-        // Add to the appropriate sorted set and notify via signal
-        if (IsUpscaleTask(taskData))
+        await _enqueueSemaphore.WaitAsync();
+        try
         {
-            bool added;
-            lock (_upscaleTasksLock)
+            using IServiceScope scope = _scopeFactory.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            bool isUpscale = IsUpscaleTask(taskData);
+            int? newChapterId = GetChapterId(taskData);
+            int? targetOrder = null;
+            Chapter? newChapter = null;
+
+            if (newChapterId.HasValue)
             {
-                added = _upscaleTasks.Add(taskItem);
+                newChapter = await dbContext
+                    .Chapters.Include(c => c.Manga)
+                    .FirstOrDefaultAsync(c => c.Id == newChapterId.Value);
             }
-            if (added)
+
+            if (newChapter != null)
             {
-                await _upscaleChannel.Writer.WriteAsync(Signal);
+                var activeTasks = await dbContext
+                    .PersistedTasks.Where(t =>
+                        t.Status == PersistedTaskStatus.Pending
+                        || t.Status == PersistedTaskStatus.Processing
+                        || t.Status == PersistedTaskStatus.Failed
+                    )
+                    .OrderBy(t => t.Order)
+                    .ToListAsync();
+
+                var queueTasks = activeTasks
+                    .Where(t => IsUpscaleTask(t.Data) == isUpscale)
+                    .ToList();
+
+                var activeChapterIds = queueTasks
+                    .Select(t => GetChapterId(t.Data))
+                    .Where(id => id.HasValue)
+                    .Select(id => id!.Value)
+                    .Distinct()
+                    .ToList();
+
+                var chaptersMap = await dbContext
+                    .Chapters.Where(c => activeChapterIds.Contains(c.Id))
+                    .ToDictionaryAsync(c => c.Id);
+
+                foreach (var t in queueTasks)
+                {
+                    if (
+                        t.Status != PersistedTaskStatus.Pending
+                        && t.Status != PersistedTaskStatus.Failed
+                    )
+                    {
+                        continue;
+                    }
+
+                    int? existChapterId = GetChapterId(t.Data);
+                    if (
+                        existChapterId.HasValue
+                        && chaptersMap.TryGetValue(existChapterId.Value, out var existChapter)
+                    )
+                    {
+                        if (CompareChapters(newChapter, existChapter) < 0)
+                        {
+                            targetOrder = t.Order;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            int finalOrder;
+            if (targetOrder.HasValue)
+            {
+                finalOrder = targetOrder.Value;
+
+                var tasksToShift = await dbContext
+                    .PersistedTasks.Where(t => t.Order >= finalOrder)
+                    .ToListAsync();
+
+                foreach (var t in tasksToShift)
+                {
+                    t.Order += 1;
+                }
+            }
+            else
+            {
+                int maxOrder = await dbContext.PersistedTasks.MaxAsync(t => (int?)t.Order) ?? 0;
+                finalOrder = maxOrder + 1;
+            }
+
+            var taskItem = new PersistedTask { Data = taskData, Order = finalOrder };
+            await dbContext.PersistedTasks.AddAsync(taskItem);
+            await dbContext.SaveChangesAsync();
+
+            if (isUpscale)
+            {
+                bool added;
+                lock (_upscaleTasksLock)
+                {
+                    if (targetOrder.HasValue)
+                    {
+                        var tasksToUpdate = _upscaleTasks
+                            .Where(t => t.Order >= targetOrder.Value)
+                            .ToList();
+                        foreach (var t in tasksToUpdate)
+                        {
+                            _upscaleTasks.Remove(t);
+                        }
+                        foreach (var t in tasksToUpdate)
+                        {
+                            t.Order += 1;
+                            _upscaleTasks.Add(t);
+                        }
+                    }
+                    added = _upscaleTasks.Add(taskItem);
+                }
+                if (added)
+                {
+                    await _upscaleChannel.Writer.WriteAsync(Signal);
+                }
+            }
+            else
+            {
+                bool added;
+                lock (_standardTasksLock)
+                {
+                    if (targetOrder.HasValue)
+                    {
+                        var tasksToUpdate = _standardTasks
+                            .Where(t => t.Order >= targetOrder.Value)
+                            .ToList();
+                        foreach (var t in tasksToUpdate)
+                        {
+                            _standardTasks.Remove(t);
+                        }
+                        foreach (var t in tasksToUpdate)
+                        {
+                            t.Order += 1;
+                            _standardTasks.Add(t);
+                        }
+                    }
+                    added = _standardTasks.Add(taskItem);
+                }
+                if (added)
+                {
+                    await _standardChannel.Writer.WriteAsync(Signal);
+                }
+            }
+
+            TaskEnqueuedOrChanged?.Invoke(taskItem);
+
+            var queueCleanup = scope.ServiceProvider.GetRequiredService<IQueueCleanup>();
+            var removedTaskIds = await queueCleanup.CleanupAsync();
+
+            if (TaskRemoved != null && removedTaskIds.Count > 0)
+            {
+                await Task.WhenAll(
+                    removedTaskIds.Select(id => TaskRemoved(new PersistedTask { Id = id }))
+                );
             }
         }
-        else
+        finally
         {
-            bool added;
-            lock (_standardTasksLock)
-            {
-                added = _standardTasks.Add(taskItem);
-            }
-            if (added)
-            {
-                await _standardChannel.Writer.WriteAsync(Signal);
-            }
-        }
-
-        TaskEnqueuedOrChanged?.Invoke(taskItem);
-
-        var queueCleanup = scope.ServiceProvider.GetRequiredService<IQueueCleanup>();
-        var removedTaskIds = await queueCleanup.CleanupAsync();
-
-        if (TaskRemoved != null && removedTaskIds.Count > 0)
-        {
-            await Task.WhenAll(
-                removedTaskIds.Select(id => TaskRemoved(new PersistedTask { Id = id }))
-            );
+            _enqueueSemaphore.Release();
         }
     }
 
@@ -389,4 +509,36 @@ public class TaskQueue : ITaskQueue, IHostedService
 
     public event Func<PersistedTask, Task>? TaskEnqueuedOrChanged;
     public event Func<PersistedTask, Task>? TaskRemoved;
+
+    private static readonly NaturalSortComparer<Chapter> _chapterNameComparer = new(c =>
+        c.FileName
+    );
+
+    private static int? GetChapterId(BaseTask data)
+    {
+        return data is IChapterTask chapterTask ? chapterTask.ChapterId : null;
+    }
+
+    private static int CompareChapters(Chapter a, Chapter b)
+    {
+        if (a.MangaId != b.MangaId)
+        {
+            return 0;
+        }
+
+        var numAStr = ChapterNumberHelper.ExtractChapterNumber(a.FileName);
+        var numBStr = ChapterNumberHelper.ExtractChapterNumber(b.FileName);
+
+        if (
+            numAStr != null
+            && numBStr != null
+            && decimal.TryParse(numAStr, out decimal numA)
+            && decimal.TryParse(numBStr, out decimal numB)
+        )
+        {
+            return numA.CompareTo(numB);
+        }
+
+        return _chapterNameComparer.Compare(a, b);
+    }
 }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -275,10 +275,6 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     await TaskEnqueuedOrChanged.Invoke(t);
                 }
-            }
-
-            if (TaskEnqueuedOrChanged != null)
-            {
                 await TaskEnqueuedOrChanged.Invoke(taskItem);
             }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -214,7 +214,9 @@ public class TaskQueue : ITaskQueue, IHostedService
                 {
                     if (targetOrder.HasValue)
                     {
-                        var upscaleToUpdate = _upscaleTasks.Where(t => t.Order >= targetOrder.Value).ToList();
+                        var upscaleToUpdate = _upscaleTasks
+                            .Where(t => t.Order >= targetOrder.Value)
+                            .ToList();
                         foreach (var t in upscaleToUpdate)
                         {
                             _upscaleTasks.Remove(t);
@@ -225,7 +227,9 @@ public class TaskQueue : ITaskQueue, IHostedService
                             _upscaleTasks.Add(t);
                         }
 
-                        var standardToUpdate = _standardTasks.Where(t => t.Order >= targetOrder.Value).ToList();
+                        var standardToUpdate = _standardTasks
+                            .Where(t => t.Order >= targetOrder.Value)
+                            .ToList();
                         foreach (var t in standardToUpdate)
                         {
                             _standardTasks.Remove(t);
@@ -530,11 +534,23 @@ public class TaskQueue : ITaskQueue, IHostedService
         if (
             numAStr != null
             && numBStr != null
-            && decimal.TryParse(numAStr, out decimal numA)
-            && decimal.TryParse(numBStr, out decimal numB)
+            && decimal.TryParse(
+                numAStr,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out decimal numA
+            )
+            && decimal.TryParse(
+                numBStr,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out decimal numB
+            )
         )
         {
-            return numA.CompareTo(numB);
+            int comparison = numA.CompareTo(numB);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
         }
 
         return _chapterNameComparer.Compare(a, b);

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -194,6 +194,7 @@ public class TaskQueue : ITaskQueue, IHostedService
                         && (
                             t.Status == PersistedTaskStatus.Pending
                             || t.Status == PersistedTaskStatus.Failed
+                            || t.Status == PersistedTaskStatus.Canceled
                         )
                     )
                     .ToListAsync();

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -189,7 +189,13 @@ public class TaskQueue : ITaskQueue, IHostedService
                 finalOrder = targetOrder.Value;
 
                 var tasksToShift = await dbContext
-                    .PersistedTasks.Where(t => t.Order >= finalOrder)
+                    .PersistedTasks.Where(t =>
+                        t.Order >= finalOrder
+                        && (
+                            t.Status == PersistedTaskStatus.Pending
+                            || t.Status == PersistedTaskStatus.Failed
+                        )
+                    )
                     .ToListAsync();
 
                 foreach (var t in tasksToShift)
@@ -207,6 +213,7 @@ public class TaskQueue : ITaskQueue, IHostedService
             await dbContext.PersistedTasks.AddAsync(taskItem);
             await dbContext.SaveChangesAsync();
 
+            var shiftedTasks = new List<PersistedTask>();
             bool added = false;
             lock (_upscaleTasksLock)
             {
@@ -226,6 +233,7 @@ public class TaskQueue : ITaskQueue, IHostedService
                             t.Order += 1;
                             _upscaleTasks.Add(t);
                         }
+                        shiftedTasks.AddRange(upscaleToUpdate);
 
                         var standardToUpdate = _standardTasks
                             .Where(t => t.Order >= targetOrder.Value)
@@ -239,6 +247,7 @@ public class TaskQueue : ITaskQueue, IHostedService
                             t.Order += 1;
                             _standardTasks.Add(t);
                         }
+                        shiftedTasks.AddRange(standardToUpdate);
                     }
 
                     if (isUpscale)
@@ -261,6 +270,14 @@ public class TaskQueue : ITaskQueue, IHostedService
                 else
                 {
                     await _standardChannel.Writer.WriteAsync(Signal);
+                }
+            }
+
+            if (TaskEnqueuedOrChanged != null)
+            {
+                foreach (var t in shiftedTasks)
+                {
+                    _ = TaskEnqueuedOrChanged.Invoke(t);
                 }
             }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskQueue.cs
@@ -548,11 +548,13 @@ public class TaskQueue : ITaskQueue, IHostedService
             && numBStr != null
             && decimal.TryParse(
                 numAStr,
+                System.Globalization.NumberStyles.Number,
                 System.Globalization.CultureInfo.InvariantCulture,
                 out decimal numA
             )
             && decimal.TryParse(
                 numBStr,
+                System.Globalization.NumberStyles.Number,
                 System.Globalization.CultureInfo.InvariantCulture,
                 out decimal numB
             )

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/ApplySplitsTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/ApplySplitsTask.cs
@@ -3,7 +3,7 @@ using MangaIngestWithUpscaling.Services.Analysis;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class ApplySplitsTask : BaseTask
+public class ApplySplitsTask : BaseTask, IChapterTask
 {
     public int ChapterId { get; set; }
     public int DetectorVersion { get; set; }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/DetectSplitCandidatesTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/DetectSplitCandidatesTask.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Localization;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class DetectSplitCandidatesTask : BaseTask
+public class DetectSplitCandidatesTask : BaseTask, IChapterTask
 {
     public int ChapterId { get; set; }
     public int DetectorVersion { get; set; }

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/IChapterTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/IChapterTask.cs
@@ -1,0 +1,9 @@
+namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
+
+/// <summary>
+/// Represents a background task that is associated with a specific chapter.
+/// </summary>
+public interface IChapterTask
+{
+    int ChapterId { get; }
+}

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RenameUpscaledChaptersSeriesTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RenameUpscaledChaptersSeriesTask.cs
@@ -1,4 +1,4 @@
-﻿using MangaIngestWithUpscaling.Data;
+using MangaIngestWithUpscaling.Data;
 using MangaIngestWithUpscaling.Data.LibraryManagement;
 using MangaIngestWithUpscaling.Services.MetadataHandling;
 using MangaIngestWithUpscaling.Shared.Services.FileSystem;
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Localization;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class RenameUpscaledChaptersSeriesTask : BaseTask
+public class RenameUpscaledChaptersSeriesTask : BaseTask, IChapterTask
 {
     public RenameUpscaledChaptersSeriesTask() { }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RepairUpscaleTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/RepairUpscaleTask.cs
@@ -15,7 +15,7 @@ namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 /// Task for repairing partially corrupted upscaled chapters by upscaling only missing pages
 /// and removing extra pages, then merging them back into the existing CBZ.
 /// </summary>
-public class RepairUpscaleTask : BaseTask
+public class RepairUpscaleTask : BaseTask, IChapterTask
 {
     public RepairUpscaleTask() { }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/UpscaleTask.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/Tasks/UpscaleTask.cs
@@ -1,4 +1,4 @@
-﻿using MangaIngestWithUpscaling.Data;
+using MangaIngestWithUpscaling.Data;
 using MangaIngestWithUpscaling.Data.Analysis;
 using MangaIngestWithUpscaling.Data.LibraryManagement;
 using MangaIngestWithUpscaling.Services.Integrations;
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Localization;
 
 namespace MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
 
-public class UpscaleTask : BaseTask
+public class UpscaleTask : BaseTask, IChapterTask
 {
     public UpscaleTask() { }
 

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -620,4 +620,353 @@ public class TaskQueueTests : IDisposable
         Assert.Equal(chapter3.Id, ((UpscaleTask)snapshotAfter[3].Data).ChapterId);
         Assert.Equal(22, snapshotAfter[3].Order);
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldKeepDifferentMangaSeriesIndependent()
+    {
+        // Arrange
+        var library = new Library
+        {
+            Name = "TestLib3",
+            NotUpscaledLibraryPath = "not_upscaled3",
+            UpscaledLibraryPath = "upscaled3",
+        };
+        var upscalerProfile = new UpscalerProfile
+        {
+            Name = "TestProfile3",
+            ScalingFactor = ScaleFactor.TwoX,
+            CompressionFormat = CompressionFormat.Png,
+            Quality = 90,
+        };
+        _dbContext.Libraries.Add(library);
+        _dbContext.UpscalerProfiles.Add(upscalerProfile);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var mangaA = new Manga
+        {
+            PrimaryTitle = "MangaA",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        var mangaB = new Manga
+        {
+            PrimaryTitle = "MangaB",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        _dbContext.MangaSeries.AddRange(mangaA, mangaB);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var chapterA2 = new Chapter
+        {
+            MangaId = mangaA.Id,
+            Manga = mangaA,
+            FileName = "Chapter 2.cbz",
+            RelativePath = "chA2.cbz",
+        };
+        var chapterA1 = new Chapter
+        {
+            MangaId = mangaA.Id,
+            Manga = mangaA,
+            FileName = "Chapter 1.cbz",
+            RelativePath = "chA1.cbz",
+        };
+        var chapterB1 = new Chapter
+        {
+            MangaId = mangaB.Id,
+            Manga = mangaB,
+            FileName = "Chapter 1.cbz",
+            RelativePath = "chB1.cbz",
+        };
+        _dbContext.Chapters.AddRange(chapterA2, chapterA1, chapterB1);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        // 1. Enqueue Manga A Chapter 2 first
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapterA2, upscalerProfile)); // gets Order = 1
+        // 2. Enqueue Manga B Chapter 1 second
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapterB1, upscalerProfile)); // gets Order = 2
+        // 3. Enqueue Manga A Chapter 1 third. Since it's Manga A, it should only compare with Manga A Chapter 2 (Order = 1)
+        // and sort before it, getting Order = 1, shifting Manga A Chapter 2 to 2, and Manga B Chapter 1 to 3.
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapterA1, upscalerProfile));
+
+        // Assert
+        var snapshot = _taskQueue.GetUpscaleSnapshot();
+        Assert.Equal(3, snapshot.Count);
+
+        // Expected order by Order field:
+        // Index 0: Manga A Chapter 1 (Order 1)
+        // Index 1: Manga A Chapter 2 (Order 2)
+        // Index 2: Manga B Chapter 1 (Order 3)
+        Assert.Equal(chapterA1.Id, ((UpscaleTask)snapshot[0].Data).ChapterId);
+        Assert.Equal(1, snapshot[0].Order);
+
+        Assert.Equal(chapterA2.Id, ((UpscaleTask)snapshot[1].Data).ChapterId);
+        Assert.Equal(2, snapshot[1].Order);
+
+        Assert.Equal(chapterB1.Id, ((UpscaleTask)snapshot[2].Data).ChapterId);
+        Assert.Equal(3, snapshot[2].Order);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldNotInsertBeforeOrShiftProcessingTasks()
+    {
+        // Arrange
+        var library = new Library
+        {
+            Name = "TestLib4",
+            NotUpscaledLibraryPath = "not_upscaled4",
+            UpscaledLibraryPath = "upscaled4",
+        };
+        var upscalerProfile = new UpscalerProfile
+        {
+            Name = "TestProfile4",
+            ScalingFactor = ScaleFactor.TwoX,
+            CompressionFormat = CompressionFormat.Png,
+            Quality = 90,
+        };
+        _dbContext.Libraries.Add(library);
+        _dbContext.UpscalerProfiles.Add(upscalerProfile);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manga = new Manga
+        {
+            PrimaryTitle = "TestManga4",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        _dbContext.MangaSeries.Add(manga);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var chapter2 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 2.cbz",
+            RelativePath = "ch2.cbz",
+        };
+        var chapter1 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 1.cbz",
+            RelativePath = "ch1.cbz",
+        };
+        var chapter3 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 3.cbz",
+            RelativePath = "ch3.cbz",
+        };
+        _dbContext.Chapters.AddRange(chapter1, chapter2, chapter3);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Manually insert Chapter 2 as Processing (Order = 10) and Chapter 3 as Pending (Order = 20)
+        var dbTaskForCh2 = new PersistedTask
+        {
+            Data = new UpscaleTask(chapter2, upscalerProfile),
+            Order = 10,
+            Status = PersistedTaskStatus.Processing,
+        };
+        var dbTaskForCh3 = new PersistedTask
+        {
+            Data = new UpscaleTask(chapter3, upscalerProfile),
+            Order = 20,
+            Status = PersistedTaskStatus.Pending,
+        };
+        _dbContext.PersistedTasks.AddRange(dbTaskForCh2, dbTaskForCh3);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
+
+        // Act
+        // Enqueue Chapter 1.
+        // It compares with Chapter 2 (Processing) -> skipped because it is Processing.
+        // It compares with Chapter 3 (Pending) -> 1 < 3 -> matches!
+        // So Chapter 1 should get Order = 20, shifting Chapter 3 to 21. Chapter 2 should remain untouched at Order 10.
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapter1, upscalerProfile));
+
+        // Assert
+        var dbTasks = await _dbContext
+            .PersistedTasks.AsNoTracking()
+            .OrderBy(t => t.Order)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(3, dbTasks.Count);
+
+        // Ch 2 (Order 10, Processing)
+        Assert.Equal(chapter2.Id, ((UpscaleTask)dbTasks[0].Data).ChapterId);
+        Assert.Equal(10, dbTasks[0].Order);
+        Assert.Equal(PersistedTaskStatus.Processing, dbTasks[0].Status);
+
+        // Ch 1 (Order 20, Pending)
+        Assert.Equal(chapter1.Id, ((UpscaleTask)dbTasks[1].Data).ChapterId);
+        Assert.Equal(20, dbTasks[1].Order);
+
+        // Ch 3 (Order 21, Pending)
+        Assert.Equal(chapter3.Id, ((UpscaleTask)dbTasks[2].Data).ChapterId);
+        Assert.Equal(21, dbTasks[2].Order);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldHandleNonNumericAndMixedFormatsWithNaturalSort()
+    {
+        // Arrange
+        var library = new Library
+        {
+            Name = "TestLib5",
+            NotUpscaledLibraryPath = "not_upscaled5",
+            UpscaledLibraryPath = "upscaled5",
+        };
+        var upscalerProfile = new UpscalerProfile
+        {
+            Name = "TestProfile5",
+            ScalingFactor = ScaleFactor.TwoX,
+            CompressionFormat = CompressionFormat.Png,
+            Quality = 90,
+        };
+        _dbContext.Libraries.Add(library);
+        _dbContext.UpscalerProfiles.Add(upscalerProfile);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manga = new Manga
+        {
+            PrimaryTitle = "TestManga5",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        _dbContext.MangaSeries.Add(manga);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var chapterB = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Special Chapter B.cbz",
+            RelativePath = "chB.cbz",
+        };
+        var chapterA = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Special Chapter A.cbz",
+            RelativePath = "chA.cbz",
+        };
+        _dbContext.Chapters.AddRange(chapterB, chapterA);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        // 1. Enqueue B first
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapterB, upscalerProfile)); // gets Order = 1
+        // 2. Enqueue A second (since it has no chapter numbers, it falls back to NaturalSortComparer and sorts A before B)
+        // A gets Order = 1, B gets shifted to 2.
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapterA, upscalerProfile));
+
+        // Assert
+        var snapshot = _taskQueue.GetUpscaleSnapshot();
+        Assert.Equal(2, snapshot.Count);
+
+        Assert.Equal(chapterA.Id, ((UpscaleTask)snapshot[0].Data).ChapterId);
+        Assert.Equal(1, snapshot[0].Order);
+
+        Assert.Equal(chapterB.Id, ((UpscaleTask)snapshot[1].Data).ChapterId);
+        Assert.Equal(2, snapshot[1].Order);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldSynchronizeInMemoryOrderForBothQueues()
+    {
+        // Arrange
+        var library = new Library
+        {
+            Name = "TestLib6",
+            NotUpscaledLibraryPath = "not_upscaled6",
+            UpscaledLibraryPath = "upscaled6",
+        };
+        var upscalerProfile = new UpscalerProfile
+        {
+            Name = "TestProfile6",
+            ScalingFactor = ScaleFactor.TwoX,
+            CompressionFormat = CompressionFormat.Png,
+            Quality = 90,
+        };
+        _dbContext.Libraries.Add(library);
+        _dbContext.UpscalerProfiles.Add(upscalerProfile);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manga = new Manga
+        {
+            PrimaryTitle = "TestManga6",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        _dbContext.MangaSeries.Add(manga);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var chapter2 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 2.cbz",
+            RelativePath = "ch2.cbz",
+        };
+        var chapter1 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 1.cbz",
+            RelativePath = "ch1.cbz",
+        };
+        _dbContext.Chapters.AddRange(chapter2, chapter1);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // 1. Enqueue UpscaleTask for Chapter 2
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapter2, upscalerProfile)); // gets Order = 1
+        // 2. Enqueue Standard Task (LoggingTask)
+        await _taskQueue.EnqueueAsync(new LoggingTask { Message = "log1" }); // gets Order = 2
+
+        // Act
+        // 3. Enqueue UpscaleTask for Chapter 1.
+        // It compares with Chapter 2 (Order = 1) -> 1 < 2 -> targetOrder = 1.
+        // It should shift Chapter 2 to Order = 2, and LoggingTask to Order = 3.
+        // UpscaleTask Chapter 1 gets Order = 1.
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapter1, upscalerProfile));
+
+        // Assert
+        var upscaleSnapshot = _taskQueue.GetUpscaleSnapshot();
+        var standardSnapshot = _taskQueue.GetStandardSnapshot();
+
+        Assert.Equal(2, upscaleSnapshot.Count);
+        Assert.Single(standardSnapshot);
+
+        // Upscale tasks
+        Assert.Equal(chapter1.Id, ((UpscaleTask)upscaleSnapshot[0].Data).ChapterId);
+        Assert.Equal(1, upscaleSnapshot[0].Order);
+
+        Assert.Equal(chapter2.Id, ((UpscaleTask)upscaleSnapshot[1].Data).ChapterId);
+        Assert.Equal(2, upscaleSnapshot[1].Order);
+
+        // Standard task
+        Assert.Equal("log1", ((LoggingTask)standardSnapshot[0].Data).Message);
+        Assert.Equal(3, standardSnapshot[0].Order);
+
+        // Double check database state to ensure perfect alignment
+        var dbTasks = await _dbContext
+            .PersistedTasks.AsNoTracking()
+            .OrderBy(t => t.Order)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(3, dbTasks.Count);
+        Assert.Equal(1, dbTasks[0].Order);
+        Assert.Equal(2, dbTasks[1].Order);
+        Assert.Equal(3, dbTasks[2].Order);
+    }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -1,7 +1,9 @@
 using MangaIngestWithUpscaling.Data;
 using MangaIngestWithUpscaling.Data.BackgroundTaskQueue;
+using MangaIngestWithUpscaling.Data.LibraryManagement;
 using MangaIngestWithUpscaling.Services.BackgroundTaskQueue;
 using MangaIngestWithUpscaling.Services.BackgroundTaskQueue.Tasks;
+using MangaIngestWithUpscaling.Shared.Data.LibraryManagement;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -405,5 +407,217 @@ public class TaskQueueTests : IDisposable
         // Assert
         Assert.True(_taskQueue.StandardReader.TryRead(out _), "Stale signal should be present");
         Assert.Null(_taskQueue.DequeueStandard());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldInsertInLogicalChapterOrder()
+    {
+        // Arrange
+        var library = new Library
+        {
+            Name = "TestLib",
+            NotUpscaledLibraryPath = "not_upscaled",
+            UpscaledLibraryPath = "upscaled",
+        };
+        var upscalerProfile = new UpscalerProfile
+        {
+            Name = "TestProfile",
+            ScalingFactor = ScaleFactor.TwoX,
+            CompressionFormat = CompressionFormat.Png,
+            Quality = 90,
+        };
+        _dbContext.Libraries.Add(library);
+        _dbContext.UpscalerProfiles.Add(upscalerProfile);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manga = new Manga
+        {
+            PrimaryTitle = "TestManga",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        _dbContext.MangaSeries.Add(manga);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var chapter2 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 2.cbz",
+            RelativePath = "ch2.cbz",
+        };
+        var chapter1 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 1.cbz",
+            RelativePath = "ch1.cbz",
+        };
+        var chapter3 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 3.cbz",
+            RelativePath = "ch3.cbz",
+        };
+        _dbContext.Chapters.AddRange(chapter1, chapter2, chapter3);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var taskForCh2 = new UpscaleTask(chapter2, upscalerProfile);
+        var taskForCh1 = new UpscaleTask(chapter1, upscalerProfile);
+        var taskForCh3 = new UpscaleTask(chapter3, upscalerProfile);
+
+        // Act
+        // 1. Enqueue Chapter 2 first
+        await _taskQueue.EnqueueAsync(taskForCh2);
+
+        // 2. Enqueue Chapter 1 second (should be sorted before Chapter 2)
+        await _taskQueue.EnqueueAsync(taskForCh1);
+
+        // 3. Enqueue Chapter 3 third (should be sorted after Chapter 2)
+        await _taskQueue.EnqueueAsync(taskForCh3);
+
+        // Assert
+        var snapshot = _taskQueue.GetUpscaleSnapshot();
+        Assert.Equal(3, snapshot.Count);
+
+        var firstTask = snapshot[0];
+        var secondTask = snapshot[1];
+        var thirdTask = snapshot[2];
+
+        Assert.Equal(chapter1.Id, ((UpscaleTask)firstTask.Data).ChapterId);
+        Assert.Equal(chapter2.Id, ((UpscaleTask)secondTask.Data).ChapterId);
+        Assert.Equal(chapter3.Id, ((UpscaleTask)thirdTask.Data).ChapterId);
+
+        // Verify they are dequeued in the correct order
+        var dequeued1 = _taskQueue.DequeueUpscale();
+        var dequeued2 = _taskQueue.DequeueUpscale();
+        var dequeued3 = _taskQueue.DequeueUpscale();
+
+        Assert.NotNull(dequeued1);
+        Assert.NotNull(dequeued2);
+        Assert.NotNull(dequeued3);
+
+        Assert.Equal(chapter1.Id, ((UpscaleTask)dequeued1.Data).ChapterId);
+        Assert.Equal(chapter2.Id, ((UpscaleTask)dequeued2.Data).ChapterId);
+        Assert.Equal(chapter3.Id, ((UpscaleTask)dequeued3.Data).ChapterId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldRespectFirstOpportunity_WhenQueueIsAlreadyMixed()
+    {
+        // Arrange
+        var library = new Library
+        {
+            Name = "TestLib2",
+            NotUpscaledLibraryPath = "not_upscaled2",
+            UpscaledLibraryPath = "upscaled2",
+        };
+        var upscalerProfile = new UpscalerProfile
+        {
+            Name = "TestProfile2",
+            ScalingFactor = ScaleFactor.TwoX,
+            CompressionFormat = CompressionFormat.Png,
+            Quality = 90,
+        };
+        _dbContext.Libraries.Add(library);
+        _dbContext.UpscalerProfiles.Add(upscalerProfile);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manga = new Manga
+        {
+            PrimaryTitle = "TestManga2",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        _dbContext.MangaSeries.Add(manga);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var chapter2 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 2.cbz",
+            RelativePath = "ch2.cbz",
+        };
+        var chapter1 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 1.cbz",
+            RelativePath = "ch1.cbz",
+        };
+        var chapter1_5 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 1.5.cbz",
+            RelativePath = "ch1_5.cbz",
+        };
+        var chapter3 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 3.cbz",
+            RelativePath = "ch3.cbz",
+        };
+        _dbContext.Chapters.AddRange(chapter1, chapter2, chapter1_5, chapter3);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // We manually insert Chapter 2 (Order = 10) and Chapter 1 (Order = 20) in the DB
+        var dbTaskForCh2 = new PersistedTask
+        {
+            Data = new UpscaleTask(chapter2, upscalerProfile),
+            Order = 10,
+            Status = PersistedTaskStatus.Pending,
+        };
+        var dbTaskForCh1 = new PersistedTask
+        {
+            Data = new UpscaleTask(chapter1, upscalerProfile),
+            Order = 20,
+            Status = PersistedTaskStatus.Pending,
+        };
+        _dbContext.PersistedTasks.AddRange(dbTaskForCh2, dbTaskForCh1);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Load them into the in-memory queue
+        await _taskQueue.ReplayPendingOrFailed(TestContext.Current.CancellationToken);
+
+        var snapshotBefore = _taskQueue.GetUpscaleSnapshot();
+        Assert.Equal(2, snapshotBefore.Count);
+        Assert.Equal(10, snapshotBefore[0].Order); // Ch 2
+        Assert.Equal(20, snapshotBefore[1].Order); // Ch 1
+
+        // Act
+        // 1. Enqueue Chapter 1.5. Since it's < Chapter 2, it should be sorted before Chapter 2 (first opportunity).
+        // It gets Order = 10, Chapter 2 gets shifted to 11, Chapter 1 gets shifted to 21.
+        var taskForCh1_5 = new UpscaleTask(chapter1_5, upscalerProfile);
+        await _taskQueue.EnqueueAsync(taskForCh1_5);
+
+        // 2. Enqueue Chapter 3. Since it's > Chapter 2 and > Chapter 1, it matches nothing, so it goes to the end.
+        // Order = maxOrder + 1 = 22.
+        var taskForCh3 = new UpscaleTask(chapter3, upscalerProfile);
+        await _taskQueue.EnqueueAsync(taskForCh3);
+
+        // Assert
+        var snapshotAfter = _taskQueue.GetUpscaleSnapshot();
+        Assert.Equal(4, snapshotAfter.Count);
+
+        // Expected sorted order: Ch 1.5 (Order 10), Ch 2 (Order 11), Ch 1 (Order 21), Ch 3 (Order 22)
+        Assert.Equal(chapter1_5.Id, ((UpscaleTask)snapshotAfter[0].Data).ChapterId);
+        Assert.Equal(10, snapshotAfter[0].Order);
+
+        Assert.Equal(chapter2.Id, ((UpscaleTask)snapshotAfter[1].Data).ChapterId);
+        Assert.Equal(11, snapshotAfter[1].Order);
+
+        Assert.Equal(chapter1.Id, ((UpscaleTask)snapshotAfter[2].Data).ChapterId);
+        Assert.Equal(21, snapshotAfter[2].Order);
+
+        Assert.Equal(chapter3.Id, ((UpscaleTask)snapshotAfter[3].Data).ChapterId);
+        Assert.Equal(22, snapshotAfter[3].Order);
     }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -968,4 +968,82 @@ public class TaskQueueTests : IDisposable
         Assert.Equal(2, dbTasks[1].Order);
         Assert.Equal(3, dbTasks[2].Order);
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task EnqueueAsync_ShouldRaiseTaskEnqueuedOrChangedForShiftedTasks()
+    {
+        // Arrange
+        var library = new Library
+        {
+            Name = "TestLib7",
+            NotUpscaledLibraryPath = "not_upscaled7",
+            UpscaledLibraryPath = "upscaled7",
+        };
+        var upscalerProfile = new UpscalerProfile
+        {
+            Name = "TestProfile7",
+            ScalingFactor = ScaleFactor.TwoX,
+            CompressionFormat = CompressionFormat.Png,
+            Quality = 90,
+        };
+        _dbContext.Libraries.Add(library);
+        _dbContext.UpscalerProfiles.Add(upscalerProfile);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var manga = new Manga
+        {
+            PrimaryTitle = "TestManga7",
+            LibraryId = library.Id,
+            Library = library,
+            UpscalerProfilePreference = upscalerProfile,
+        };
+        _dbContext.MangaSeries.Add(manga);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var chapter2 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 2.cbz",
+            RelativePath = "ch2.cbz",
+        };
+        var chapter1 = new Chapter
+        {
+            MangaId = manga.Id,
+            Manga = manga,
+            FileName = "Chapter 1.cbz",
+            RelativePath = "ch1.cbz",
+        };
+        _dbContext.Chapters.AddRange(chapter2, chapter1);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Enqueue Chapter 2 (Order = 1)
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapter2, upscalerProfile));
+
+        var raisedTasks = new List<PersistedTask>();
+        _taskQueue.TaskEnqueuedOrChanged += (task) =>
+        {
+            raisedTasks.Add(task);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        // Enqueue Chapter 1 (Order = 1, shifting Chapter 2 to 2)
+        await _taskQueue.EnqueueAsync(new UpscaleTask(chapter1, upscalerProfile));
+
+        // Assert
+        // We expect two event triggers:
+        // 1. For Chapter 2 (order shifted to 2)
+        // 2. For Chapter 1 (newly enqueued at order 1)
+        Assert.Equal(2, raisedTasks.Count);
+
+        var shiftedTask = raisedTasks[0];
+        Assert.Equal(chapter2.Id, ((UpscaleTask)shiftedTask.Data).ChapterId);
+        Assert.Equal(2, shiftedTask.Order);
+
+        var newTask = raisedTasks[1];
+        Assert.Equal(chapter1.Id, ((UpscaleTask)newTask.Data).ChapterId);
+        Assert.Equal(1, newTask.Order);
+    }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskQueueTests.cs
@@ -409,20 +409,43 @@ public class TaskQueueTests : IDisposable
         Assert.Null(_taskQueue.DequeueStandard());
     }
 
-    [Fact]
+    [Theory]
+    [InlineData(
+        new[] { "Chapter 2.cbz", "Chapter 11.cbz", "Chapter 1.cbz" },
+        new[] { "Chapter 1.cbz", "Chapter 2.cbz", "Chapter 11.cbz" }
+    )]
+    [InlineData(
+        new[] { "Chapter 10.cbz", "Chapter 2.cbz" },
+        new[] { "Chapter 2.cbz", "Chapter 10.cbz" }
+    )]
+    [InlineData(
+        new[] { "Chapter 1.5.cbz", "Chapter 1.cbz", "Chapter 2.cbz" },
+        new[] { "Chapter 1.cbz", "Chapter 1.5.cbz", "Chapter 2.cbz" }
+    )]
+    [InlineData(
+        new[] { "Special B.cbz", "Special A.cbz" },
+        new[] { "Special A.cbz", "Special B.cbz" }
+    )]
+    [InlineData(
+        new[] { "Chapter 1.0.cbz", "Chapter 1.cbz" },
+        new[] { "Chapter 1.0.cbz", "Chapter 1.cbz" }
+    )]
     [Trait("Category", "Unit")]
-    public async Task EnqueueAsync_ShouldInsertInLogicalChapterOrder()
+    public async Task EnqueueAsync_ShouldInsertInLogicalChapterOrder(
+        string[] enqueueNames,
+        string[] expectedNames
+    )
     {
         // Arrange
         var library = new Library
         {
-            Name = "TestLib",
+            Name = "TestLib_" + Guid.NewGuid().ToString("N"),
             NotUpscaledLibraryPath = "not_upscaled",
             UpscaledLibraryPath = "upscaled",
         };
         var upscalerProfile = new UpscalerProfile
         {
-            Name = "TestProfile",
+            Name = "TestProfile_" + Guid.NewGuid().ToString("N"),
             ScalingFactor = ScaleFactor.TwoX,
             CompressionFormat = CompressionFormat.Png,
             Quality = 90,
@@ -433,7 +456,7 @@ public class TaskQueueTests : IDisposable
 
         var manga = new Manga
         {
-            PrimaryTitle = "TestManga",
+            PrimaryTitle = "TestManga_" + Guid.NewGuid().ToString("N"),
             LibraryId = library.Id,
             Library = library,
             UpscalerProfilePreference = upscalerProfile,
@@ -441,68 +464,44 @@ public class TaskQueueTests : IDisposable
         _dbContext.MangaSeries.Add(manga);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var chapter2 = new Chapter
+        var chapters = new List<Chapter>();
+        for (int i = 0; i < enqueueNames.Length; i++)
         {
-            MangaId = manga.Id,
-            Manga = manga,
-            FileName = "Chapter 2.cbz",
-            RelativePath = "ch2.cbz",
-        };
-        var chapter1 = new Chapter
-        {
-            MangaId = manga.Id,
-            Manga = manga,
-            FileName = "Chapter 1.cbz",
-            RelativePath = "ch1.cbz",
-        };
-        var chapter3 = new Chapter
-        {
-            MangaId = manga.Id,
-            Manga = manga,
-            FileName = "Chapter 3.cbz",
-            RelativePath = "ch3.cbz",
-        };
-        _dbContext.Chapters.AddRange(chapter1, chapter2, chapter3);
+            chapters.Add(
+                new Chapter
+                {
+                    MangaId = manga.Id,
+                    Manga = manga,
+                    FileName = enqueueNames[i],
+                    RelativePath = $"ch{i}.cbz",
+                }
+            );
+        }
+        _dbContext.Chapters.AddRange(chapters);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var taskForCh2 = new UpscaleTask(chapter2, upscalerProfile);
-        var taskForCh1 = new UpscaleTask(chapter1, upscalerProfile);
-        var taskForCh3 = new UpscaleTask(chapter3, upscalerProfile);
-
         // Act
-        // 1. Enqueue Chapter 2 first
-        await _taskQueue.EnqueueAsync(taskForCh2);
-
-        // 2. Enqueue Chapter 1 second (should be sorted before Chapter 2)
-        await _taskQueue.EnqueueAsync(taskForCh1);
-
-        // 3. Enqueue Chapter 3 third (should be sorted after Chapter 2)
-        await _taskQueue.EnqueueAsync(taskForCh3);
+        // Enqueue in the order specified in enqueueNames
+        foreach (var chapter in chapters)
+        {
+            var task = new UpscaleTask(chapter, upscalerProfile);
+            await _taskQueue.EnqueueAsync(task);
+        }
 
         // Assert
         var snapshot = _taskQueue.GetUpscaleSnapshot();
-        Assert.Equal(3, snapshot.Count);
+        Assert.Equal(expectedNames.Length, snapshot.Count);
 
-        var firstTask = snapshot[0];
-        var secondTask = snapshot[1];
-        var thirdTask = snapshot[2];
-
-        Assert.Equal(chapter1.Id, ((UpscaleTask)firstTask.Data).ChapterId);
-        Assert.Equal(chapter2.Id, ((UpscaleTask)secondTask.Data).ChapterId);
-        Assert.Equal(chapter3.Id, ((UpscaleTask)thirdTask.Data).ChapterId);
-
-        // Verify they are dequeued in the correct order
-        var dequeued1 = _taskQueue.DequeueUpscale();
-        var dequeued2 = _taskQueue.DequeueUpscale();
-        var dequeued3 = _taskQueue.DequeueUpscale();
-
-        Assert.NotNull(dequeued1);
-        Assert.NotNull(dequeued2);
-        Assert.NotNull(dequeued3);
-
-        Assert.Equal(chapter1.Id, ((UpscaleTask)dequeued1.Data).ChapterId);
-        Assert.Equal(chapter2.Id, ((UpscaleTask)dequeued2.Data).ChapterId);
-        Assert.Equal(chapter3.Id, ((UpscaleTask)dequeued3.Data).ChapterId);
+        for (int i = 0; i < expectedNames.Length; i++)
+        {
+            var task = (UpscaleTask)snapshot[i].Data;
+            var chapter = await _dbContext.Chapters.FirstOrDefaultAsync(
+                c => c.Id == task.ChapterId,
+                TestContext.Current.CancellationToken
+            );
+            Assert.NotNull(chapter);
+            Assert.Equal(expectedNames[i], chapter.FileName);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Closes #407. Implements logical chapter number ordering on enqueue, falling back to natural filename sorting via NaturalSortComparer. Introduces IChapterTask interface for clean compile-time lookup. Sets up unit tests in TaskQueueTests.