### PR TITLE
chore(deps): update dependencies to latest open Renovate versions

### DIFF
--- a/src/MangaIngestWithUpscaling/Components/FileSystem/FolderPickerViewModel.cs
+++ b/src/MangaIngestWithUpscaling/Components/FileSystem/FolderPickerViewModel.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Reactive;
 using System.Reactive.Linq;
 using MudBlazor;
 using ReactiveUI;
+using RxVoid = ReactiveUI.Primitives.RxVoid;
 
 namespace MangaIngestWithUpscaling.Components.FileSystem;
 
@@ -23,7 +24,7 @@ public class FolderPickerViewModel : ViewModelBase
 
         this.WhenAnyValue(x => x.RootDirectory)
             .Throttle(TimeSpan.FromMilliseconds(300))
-            .Select(_ => Unit.Default)
+            .Select(_ => RxVoid.Default)
             .InvokeCommand(LoadDirectoryItemsCommand);
 
         _canGoToParent = this.WhenAnyValue(x => x.RootDirectory)
@@ -71,8 +72,8 @@ public class FolderPickerViewModel : ViewModelBase
 
     public bool CanGoToParent => _canGoToParent.Value;
     public ObservableCollection<TreeItemData<DirectoryItem>> TreeItems { get; } = [];
-    public ReactiveCommand<Unit, Unit> LoadDirectoryItemsCommand { get; }
-    public ReactiveCommand<Unit, Unit> GoToParentCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> LoadDirectoryItemsCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> GoToParentCommand { get; }
     public IObservable<string?> WhenPathSelected { get; }
 
     private async Task LoadDirectoryItemsAsync()

--- a/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
+++ b/src/MangaIngestWithUpscaling/MangaIngestWithUpscaling.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.8.2" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.8.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -53,11 +53,11 @@
     />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="MudBlazor" Version="9.7.0" />
-    <PackageReference Include="MudBlazor.Translations" Version="3.3.0" />
+    <PackageReference Include="MudBlazor.Translations" Version="3.4.0" />
     <PackageReference Include="Open.ChannelExtensions" Version="10.0.0" />
     <PackageReference Include="PinguApps.Blazor.QRCode" Version="1.1.4" />
-    <PackageReference Include="ReactiveUI" Version="23.2.28" />
-    <PackageReference Include="ReactiveUI.Blazor" Version="23.2.28" />
+    <PackageReference Include="ReactiveUI" Version="24.0.0" />
+    <PackageReference Include="ReactiveUI.Blazor" Version="24.0.0" />
     <PackageReference
       Include="ReactiveMarbles.ObservableEvents.SourceGenerator"
       Version="1.3.1"

--- a/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
+++ b/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
     <PackageReference Include="MudBlazor" Version="9.7.0" />
     <PackageReference Include="NSubstitute" Version="6.0.0" />
   </ItemGroup>

--- a/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
+++ b/test/MangaIngestWithUpscaling.Tests.UI/MangaIngestWithUpscaling.Tests.UI.csproj
@@ -12,6 +12,7 @@
     <Using Include="Xunit" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="Microsoft.Build" Version="18.8.2" />
     <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" />

--- a/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
+++ b/test/MangaIngestWithUpscaling.Tests/MangaIngestWithUpscaling.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
   </ItemGroup>


### PR DESCRIPTION
### Summary of Changes

Updates project dependencies to the latest versions specified in open Renovate PRs (#423, #424, #425) and adapts code to breaking API changes:

1. **MudBlazor.Translations**: Updated from `3.3.0` to `3.4.0` ([#423](https://github.com/Lolle2000la/MangaIngestWithUpscaling/pull/423))
2. **SQLitePCLRaw.bundle_e_sqlite3**: Updated from `3.0.3` to `3.0.4` ([#424](https://github.com/Lolle2000la/MangaIngestWithUpscaling/pull/424)) across main project and test suites
3. **ReactiveUI & ReactiveUI.Blazor**: Updated from `23.2.28` to `24.0.0` ([#425](https://github.com/Lolle2000la/MangaIngestWithUpscaling/pull/425))
   - Adapted `FolderPickerViewModel` parameterless commands from `Unit` to `RxVoid` (`using RxVoid = ReactiveUI.Primitives.RxVoid;`) to align with ReactiveUI 24.0.0's move to `ReactiveUI.Primitives`.

### Validation
- Verified code formatting with `dotnet csharpier check src/ test/`
- Verified solution build with `dotnet build --no-restore MangaIngestWithUpscaling.sln`
- Executed and passed all unit, UI, shared, and remote worker test suites