### PR TITLE
Show remote processor status indicator in TaskTable

### DIFF
--- a/src/MangaIngestWithUpscaling/Components/BackgroundTaskQueue/TaskTable.razor
+++ b/src/MangaIngestWithUpscaling/Components/BackgroundTaskQueue/TaskTable.razor
@@ -1,7 +1,9 @@
-﻿@using MangaIngestWithUpscaling.Data.BackgroundTaskQueue
+@using MangaIngestWithUpscaling.Data.BackgroundTaskQueue
+@using MangaIngestWithUpscaling.Services.BackgroundTaskQueue
 @using MangaIngestWithUpscaling.Services.BackgroundTaskQueue.TaskDescribers
 @inject IStringLocalizer<TaskTable> Loc
 @inject ITaskDescriberFactory DescriberFactory
+@inject DistributedUpscaleTaskProcessor DistributedUpscaleTaskProcessor
 
 <MudTable T="PersistedTask" Items="@Tasks" RowsPerPage="10" Elevation="3" Dense="true" @ref="Table">
     <ToolBarContent>
@@ -41,6 +43,12 @@
         </MudTd>
         <MudTd DataLabel="@Loc["Header_Status"]">
             @Loc[$"Status_{context.Status}"]
+            @if (context.Status == PersistedTaskStatus.Processing && DistributedUpscaleTaskProcessor.IsRunningRemotely(context.Id))
+            {
+                <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined" Class="ml-1 my-0 pa-1" Style="font-size: 0.75rem;">
+                    @Loc["Status_Remote"]
+                </MudChip>
+            }
             @if (context.Status == PersistedTaskStatus.Processing && context.Data?.Progress is not null)
             {
                 var p = context.Data.Progress;

--- a/src/MangaIngestWithUpscaling/Resources/Components/BackgroundTaskQueue/TaskTable.de-DE.resx
+++ b/src/MangaIngestWithUpscaling/Resources/Components/BackgroundTaskQueue/TaskTable.de-DE.resx
@@ -97,4 +97,7 @@
   <data name="Status_Canceled" xml:space="preserve">
     <value>Abgebrochen</value>
   </data>
+  <data name="Status_Remote" xml:space="preserve">
+    <value>Remote</value>
+  </data>
 </root>

--- a/src/MangaIngestWithUpscaling/Resources/Components/BackgroundTaskQueue/TaskTable.en-US.resx
+++ b/src/MangaIngestWithUpscaling/Resources/Components/BackgroundTaskQueue/TaskTable.en-US.resx
@@ -97,4 +97,7 @@
   <data name="Status_Canceled" xml:space="preserve">
     <value>Canceled</value>
   </data>
+  <data name="Status_Remote" xml:space="preserve">
+    <value>Remote</value>
+  </data>
 </root>

--- a/src/MangaIngestWithUpscaling/Resources/Components/BackgroundTaskQueue/TaskTable.ja-JP.resx
+++ b/src/MangaIngestWithUpscaling/Resources/Components/BackgroundTaskQueue/TaskTable.ja-JP.resx
@@ -97,4 +97,7 @@
   <data name="Status_Canceled" xml:space="preserve">
     <value>キャンセル済み</value>
   </data>
+  <data name="Status_Remote" xml:space="preserve">
+    <value>リモート</value>
+  </data>
 </root>

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -517,6 +517,17 @@ public class DistributedUpscaleTaskProcessor(
     }
 
     /// <summary>
+    ///     Checks if a task is currently running on a remote processor.
+    /// </summary>
+    public bool IsRunningRemotely(int taskId)
+    {
+        using (_lock.EnterScope())
+        {
+            return runningTasks.ContainsKey(taskId);
+        }
+    }
+
+    /// <summary>
     ///     Applies progress updates coming from a remote worker to the running task, if any.
     ///     Backward-compatible usage via optional fields: only provided values are applied.
     /// </summary>

--- a/test/MangaIngestWithUpscaling.Tests.UI/MockStringLocalizer.cs
+++ b/test/MangaIngestWithUpscaling.Tests.UI/MockStringLocalizer.cs
@@ -37,6 +37,7 @@ public class MockStringLocalizer<T> : IStringLocalizer<T>
         { "Status_Completed", "Completed" },
         { "Status_Failed", "Failed" },
         { "Status_Canceled", "Canceled" },
+        { "Status_Remote", "Remote" },
         // EditLibraryFilters
         { "Title", "Edit Ingest Filters" },
         {

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
@@ -106,4 +106,38 @@ public class DistributedUpscaleTaskProcessorTests : IDisposable
         Assert.Equal(2, ((DetectSplitCandidatesTask)result1.Data).ChapterId);
         Assert.Equal(1, ((DetectSplitCandidatesTask)result2.Data).ChapterId);
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsRunningRemotely_ShouldReturnTrueWhileProcessingRemotely_AndFalseWhenCompleted()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        await _taskQueue.EnqueueAsync(new DetectSplitCandidatesTask(1, 1));
+
+        var runTask = _processor.StartAsync(cts.Token);
+
+        // Before GetTask, task is not running remotely
+        Assert.False(_processor.IsRunningRemotely(1));
+
+        // Act
+        var task = await _processor.GetTask(cts.Token);
+
+        // Assert while processing remotely
+        Assert.NotNull(task);
+        Assert.True(_processor.IsRunningRemotely(task.Id));
+
+        // Complete task
+        await _processor.TaskCompleted(task.Id);
+
+        // Assert after completion
+        Assert.False(_processor.IsRunningRemotely(task.Id));
+
+        await cts.CancelAsync();
+        try
+        {
+            await runTask;
+        }
+        catch (OperationCanceledException) { }
+    }
 }


### PR DESCRIPTION
## Summary
Adds a visual status indicator (`Remote` chip) to `TaskTable.razor` to indicate when a background task is currently being processed on a remote worker node.

## Changes
- **`DistributedUpscaleTaskProcessor`**: Added `IsRunningRemotely(int taskId)` method to check if a task is currently active on a remote worker.
- **`TaskTable.razor`**: Display a localized `Remote` chip in the Status column when a processing task is running remotely.
- **Localization**: Added `Status_Remote` localized string resources for English (`en-US`), German (`de-DE`), and Japanese (`ja-JP`).
- **Tests**: Added unit test `IsRunningRemotely_ShouldReturnTrueWhileProcessingRemotely_AndFalseWhenCompleted` in `DistributedUpscaleTaskProcessorTests`.