### PR TITLE
fix: harden remote task processor cancellation and gRPC communication

### DIFF
--- a/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Threading.Channels;
 using Google.Protobuf;
@@ -200,11 +200,11 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                 var sw = Stopwatch.StartNew();
                 AsyncServerStreamingCall<CbzFileChunk>? stream = client.GetCbzFile(
                     new CbzToUpscaleRequest { TaskId = resp.TaskId, Prefetch = true },
-                    cancellationToken: stoppingToken
+                    cancellationToken: persistentKeepAliveCts.Token
                 );
                 string file = await FetchFile(
                     resp.TaskId,
-                    stream.ResponseStream.ReadAllAsync(stoppingToken)
+                    stream.ResponseStream.ReadAllAsync(persistentKeepAliveCts.Token)
                 );
                 sw.Stop();
                 _predictor.RecordDownload(sw.Elapsed);
@@ -277,9 +277,30 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
             _currentTaskId = item.TaskId;
             var profile = item.Profile;
 
+            if (item.PersistentKeepAliveCts.IsCancellationRequested)
+            {
+                logger.LogInformation(
+                    "Task {TaskId} was cancelled prior to starting upscaling, skipping.",
+                    item.TaskId
+                );
+                SafeDelete(item.DownloadedFile);
+                await item.PersistentKeepAliveCts.CancelAsync();
+                try
+                {
+                    await item.PersistentKeepAliveTask;
+                }
+                catch { }
+
+                _currentTaskId = null;
+                continue;
+            }
+
             // Transition the persistent keep-alive from prefetch to processing mode
             // We'll create a new keep-alive specifically for progress reporting during upscaling
-            var upscalesCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            var upscalesCts = CancellationTokenSource.CreateLinkedTokenSource(
+                stoppingToken,
+                item.PersistentKeepAliveCts.Token
+            );
             DateTime lastProgressSend = DateTime.UtcNow.AddSeconds(-10);
             int? lastProgressCurrent = null;
             int prefetchSignaled = 0; // 0 = not signaled, 1 = signaled (atomic)
@@ -415,7 +436,10 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                                 {
                                     try
                                     {
-                                        await item.PersistentKeepAliveCts.CancelAsync();
+                                        await Task.WhenAll(
+                                            upscalesCts.CancelAsync(),
+                                            item.PersistentKeepAliveCts.CancelAsync()
+                                        );
                                     }
                                     catch { }
 
@@ -773,6 +797,34 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
 
             _uploadInProgressTaskId = item.TaskId;
 
+            if (item.PersistentKeepAliveCts.IsCancellationRequested)
+            {
+                logger.LogInformation(
+                    "Task {TaskId} was cancelled prior to upload, skipping.",
+                    item.TaskId
+                );
+                SafeDelete(item.DownloadedFile);
+                if (item.UpscaledFile != null)
+                {
+                    SafeDelete(item.UpscaledFile);
+                }
+
+                await item.PersistentKeepAliveCts.CancelAsync();
+                try
+                {
+                    await item.PersistentKeepAliveTask;
+                }
+                catch { }
+
+                _uploadInProgressTaskId = null;
+                continue;
+            }
+
+            using var uploadCts = CancellationTokenSource.CreateLinkedTokenSource(
+                stoppingToken,
+                item.PersistentKeepAliveCts.Token
+            );
+
             try
             {
                 if (item.TaskType == TaskType.SplitDetection)
@@ -787,7 +839,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                         item.TaskId,
                         item.ResultJson,
                         item.DownloadedFile,
-                        stoppingToken
+                        uploadCts.Token
                     );
                 }
                 else
@@ -803,7 +855,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                         item.UpscaledFile,
                         item.DownloadedFile,
                         item.UpscaledFile,
-                        stoppingToken
+                        uploadCts.Token
                     );
                 }
             }
@@ -1079,6 +1131,11 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                             await cts.CancelAsync();
                             break;
                         }
+                    }
+                    catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+                    {
+                        await cts.CancelAsync();
+                        break;
                     }
                     catch { }
 

--- a/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
@@ -197,28 +197,42 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     id => new KeepAliveRequest { TaskId = id, Prefetch = true }
                 );
 
-                var sw = Stopwatch.StartNew();
-                AsyncServerStreamingCall<CbzFileChunk>? stream = client.GetCbzFile(
-                    new CbzToUpscaleRequest { TaskId = resp.TaskId, Prefetch = true },
-                    cancellationToken: persistentKeepAliveCts.Token
-                );
-                string file = await FetchFile(
-                    resp.TaskId,
-                    stream.ResponseStream.ReadAllAsync(persistentKeepAliveCts.Token)
-                );
-                sw.Stop();
-                _predictor.RecordDownload(sw.Elapsed);
+                try
+                {
+                    var sw = Stopwatch.StartNew();
+                    using AsyncServerStreamingCall<CbzFileChunk> stream = client.GetCbzFile(
+                        new CbzToUpscaleRequest { TaskId = resp.TaskId, Prefetch = true },
+                        cancellationToken: persistentKeepAliveCts.Token
+                    );
+                    string file = await FetchFile(
+                        resp.TaskId,
+                        stream.ResponseStream.ReadAllAsync(persistentKeepAliveCts.Token)
+                    );
+                    sw.Stop();
+                    _predictor.RecordDownload(sw.Elapsed);
 
-                var fetched = new FetchedItem(
-                    resp.TaskId,
-                    prefetchProfile,
-                    file,
-                    persistentKeepAliveCts,
-                    persistentKeepAliveTask,
-                    resp.TaskType,
-                    resp.SplitFindingsJson
-                );
-                await _toUpscale.Writer.WriteAsync(fetched, stoppingToken);
+                    var fetched = new FetchedItem(
+                        resp.TaskId,
+                        prefetchProfile,
+                        file,
+                        persistentKeepAliveCts,
+                        persistentKeepAliveTask,
+                        resp.TaskType,
+                        resp.SplitFindingsJson
+                    );
+                    await _toUpscale.Writer.WriteAsync(fetched, stoppingToken);
+                }
+                catch
+                {
+                    await persistentKeepAliveCts.CancelAsync();
+                    try
+                    {
+                        await persistentKeepAliveTask;
+                    }
+                    catch { }
+
+                    throw;
+                }
 
                 _fetchInProgress = false;
             }
@@ -297,7 +311,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
 
             // Transition the persistent keep-alive from prefetch to processing mode
             // We'll create a new keep-alive specifically for progress reporting during upscaling
-            var upscalesCts = CancellationTokenSource.CreateLinkedTokenSource(
+            using var upscalesCts = CancellationTokenSource.CreateLinkedTokenSource(
                 stoppingToken,
                 item.PersistentKeepAliveCts.Token
             );

--- a/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
@@ -230,6 +230,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                         await persistentKeepAliveTask;
                     }
                     catch { }
+                    persistentKeepAliveCts.Dispose();
 
                     throw;
                 }
@@ -304,6 +305,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     await item.PersistentKeepAliveTask;
                 }
                 catch { }
+                item.PersistentKeepAliveCts.Dispose();
 
                 _currentTaskId = null;
                 continue;
@@ -688,6 +690,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     await item.PersistentKeepAliveTask;
                 }
                 catch { }
+                item.PersistentKeepAliveCts.Dispose();
 
                 if (Interlocked.CompareExchange(ref prefetchSignaled, 1, 0) == 0)
                 {
@@ -731,6 +734,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     await item.PersistentKeepAliveTask;
                 }
                 catch { }
+                item.PersistentKeepAliveCts.Dispose();
 
                 if (Interlocked.CompareExchange(ref prefetchSignaled, 1, 0) == 0)
                 {
@@ -829,6 +833,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     await item.PersistentKeepAliveTask;
                 }
                 catch { }
+                item.PersistentKeepAliveCts.Dispose();
 
                 _uploadInProgressTaskId = null;
                 continue;
@@ -908,6 +913,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     await item.PersistentKeepAliveTask;
                 }
                 catch { }
+                item.PersistentKeepAliveCts.Dispose();
 
                 _uploadInProgressTaskId = null;
             }

--- a/src/MangaIngestWithUpscaling/Api/Upscaling/UpscalingDistributionService.cs
+++ b/src/MangaIngestWithUpscaling/Api/Upscaling/UpscalingDistributionService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -228,9 +228,9 @@ public partial class UpscalingDistributionService(
         }
 
         var task = await dbContext.PersistedTasks.FindAsync(request.TaskId);
-        if (task == null)
+        if (task == null || task.Status == PersistedTaskStatus.Canceled)
         {
-            context.Status = new Status(StatusCode.NotFound, "Task not found");
+            context.Status = new Status(StatusCode.NotFound, "Task not found or cancelled");
             return;
         }
 
@@ -323,6 +323,15 @@ public partial class UpscalingDistributionService(
         int chunkNumber = 0;
         while ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0)
         {
+            if (
+                context.CancellationToken.IsCancellationRequested
+                || !taskProcessor.IsRunningRemotely(task.Id)
+            )
+            {
+                context.Status = new Status(StatusCode.NotFound, "Task cancelled");
+                return;
+            }
+
             await responseStream.WriteAsync(
                 new CbzFileChunk
                 {
@@ -343,9 +352,9 @@ public partial class UpscalingDistributionService(
     )
     {
         var task = await dbContext.PersistedTasks.FindAsync(request.TaskId);
-        if (task == null)
+        if (task == null || task.Status == PersistedTaskStatus.Canceled)
         {
-            context.Status = new Status(StatusCode.NotFound, "Task not found");
+            context.Status = new Status(StatusCode.NotFound, "Task not found or cancelled");
             return new CbzFileChunk();
         }
 
@@ -456,12 +465,12 @@ public partial class UpscalingDistributionService(
         try
         {
             var task = await dbContext.PersistedTasks.FindAsync(request.TaskId);
-            if (task == null)
+            if (task == null || task.Status == PersistedTaskStatus.Canceled)
             {
                 return new UploadDetectionResultResponse
                 {
                     Success = false,
-                    Message = "Task not found",
+                    Message = "Task not found or cancelled",
                 };
             }
 
@@ -560,14 +569,14 @@ public partial class UpscalingDistributionService(
                 }
 
                 PersistedTask? task = await dbContext.PersistedTasks.FindAsync(taskId);
-                if (task == null)
+                if (task == null || task.Status == PersistedTaskStatus.Canceled)
                 {
                     File.Delete(tempFile);
                     await responseStream.WriteAsync(
                         new UploadUpscaledCbzResponse
                         {
                             Success = false,
-                            Message = "Task not found",
+                            Message = "Task not found or cancelled",
                             TaskId = taskId,
                         }
                     );

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -23,6 +23,7 @@ public class DistributedUpscaleTaskProcessor(
     TaskQueue taskQueue,
     IServiceScopeFactory scopeFactory,
     IOptions<UpscalerConfig> upscalerConfig,
+    ILogger<DistributedUpscaleTaskProcessor> logger,
     ITaskPersistenceService taskPersistenceService
 ) : BackgroundService
 {
@@ -76,7 +77,7 @@ public class DistributedUpscaleTaskProcessor(
 
         if (found)
         {
-            CleanupRepairFiles(checkAgainst.Id, null);
+            CleanupRepairFiles(checkAgainst.Id, logger);
         }
 
         await taskPersistenceService.CancelTaskAsync(checkAgainst.Id);
@@ -763,7 +764,7 @@ public class DistributedUpscaleTaskProcessor(
     /// <summary>
     ///     Cleans up temporary files created during repair processing.
     /// </summary>
-    private void CleanupRepairFiles(int taskId, ILogger? logger)
+    private void CleanupRepairFiles(int taskId, ILogger logger)
     {
         try
         {
@@ -782,7 +783,7 @@ public class DistributedUpscaleTaskProcessor(
                 }
                 catch (Exception ex)
                 {
-                    logger?.LogDebug(
+                    logger.LogDebug(
                         ex,
                         "RepairContext dispose threw, continuing cleanup for task {taskId}",
                         taskId
@@ -798,7 +799,7 @@ public class DistributedUpscaleTaskProcessor(
             )
             {
                 File.Delete(repairState.PreparedMissingPagesCbzPath);
-                logger?.LogDebug(
+                logger.LogDebug(
                     "Cleaned up prepared missing pages CBZ: {path}",
                     repairState.PreparedMissingPagesCbzPath
                 );
@@ -810,7 +811,7 @@ public class DistributedUpscaleTaskProcessor(
             )
             {
                 File.Delete(repairState.UpscaledMissingPagesCbzPath);
-                logger?.LogDebug(
+                logger.LogDebug(
                     "Cleaned up upscaled missing pages CBZ: {path}",
                     repairState.UpscaledMissingPagesCbzPath
                 );
@@ -818,7 +819,7 @@ public class DistributedUpscaleTaskProcessor(
         }
         catch (Exception ex)
         {
-            logger?.LogWarning(ex, "Failed to clean up repair files for task {taskId}", taskId);
+            logger.LogWarning(ex, "Failed to clean up repair files for task {taskId}", taskId);
         }
     }
 

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -54,6 +54,7 @@ public class DistributedUpscaleTaskProcessor(
     /// <param name="checkAgainst">The task to check against if it is still the current task. Does so by using the Id.</param>
     public async Task CancelCurrent(PersistedTask checkAgainst)
     {
+        bool found;
         using (_lock.EnterScope())
         {
             if (
@@ -65,12 +66,17 @@ public class DistributedUpscaleTaskProcessor(
                 _ = StatusChanged?.Invoke(currentTask);
 
                 runningTasks.Remove(checkAgainst.Id);
-                CleanupRepairFiles(checkAgainst.Id, null);
+                found = true;
             }
             else
             {
                 return;
             }
+        }
+
+        if (found)
+        {
+            CleanupRepairFiles(checkAgainst.Id, null);
         }
 
         await taskPersistenceService.CancelTaskAsync(checkAgainst.Id);

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessor.cs
@@ -65,6 +65,7 @@ public class DistributedUpscaleTaskProcessor(
                 _ = StatusChanged?.Invoke(currentTask);
 
                 runningTasks.Remove(checkAgainst.Id);
+                CleanupRepairFiles(checkAgainst.Id, null);
             }
             else
             {
@@ -756,7 +757,7 @@ public class DistributedUpscaleTaskProcessor(
     /// <summary>
     ///     Cleans up temporary files created during repair processing.
     /// </summary>
-    private void CleanupRepairFiles(int taskId, ILogger logger)
+    private void CleanupRepairFiles(int taskId, ILogger? logger)
     {
         try
         {
@@ -775,7 +776,7 @@ public class DistributedUpscaleTaskProcessor(
                 }
                 catch (Exception ex)
                 {
-                    logger.LogDebug(
+                    logger?.LogDebug(
                         ex,
                         "RepairContext dispose threw, continuing cleanup for task {taskId}",
                         taskId
@@ -791,7 +792,7 @@ public class DistributedUpscaleTaskProcessor(
             )
             {
                 File.Delete(repairState.PreparedMissingPagesCbzPath);
-                logger.LogDebug(
+                logger?.LogDebug(
                     "Cleaned up prepared missing pages CBZ: {path}",
                     repairState.PreparedMissingPagesCbzPath
                 );
@@ -803,7 +804,7 @@ public class DistributedUpscaleTaskProcessor(
             )
             {
                 File.Delete(repairState.UpscaledMissingPagesCbzPath);
-                logger.LogDebug(
+                logger?.LogDebug(
                     "Cleaned up upscaled missing pages CBZ: {path}",
                     repairState.UpscaledMissingPagesCbzPath
                 );
@@ -811,7 +812,7 @@ public class DistributedUpscaleTaskProcessor(
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to clean up repair files for task {taskId}", taskId);
+            logger?.LogWarning(ex, "Failed to clean up repair files for task {taskId}", taskId);
         }
     }
 

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
@@ -140,4 +140,33 @@ public class DistributedUpscaleTaskProcessorTests : IDisposable
         }
         catch (OperationCanceledException) { }
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CancelCurrent_ShouldCancelRunningRemoteTask_AndRemoveFromRunningTasks()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        await _taskQueue.EnqueueAsync(new DetectSplitCandidatesTask(1, 1));
+
+        var runTask = _processor.StartAsync(cts.Token);
+        var task = await _processor.GetTask(cts.Token);
+
+        Assert.NotNull(task);
+        Assert.True(_processor.IsRunningRemotely(task.Id));
+
+        // Act
+        await _processor.CancelCurrent(task);
+
+        // Assert
+        Assert.False(_processor.IsRunningRemotely(task.Id));
+        Assert.Equal(PersistedTaskStatus.Canceled, task.Status);
+
+        await cts.CancelAsync();
+        try
+        {
+            await runTask;
+        }
+        catch (OperationCanceledException) { }
+    }
 }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/DistributedUpscaleTaskProcessorTests.cs
@@ -57,6 +57,7 @@ public class DistributedUpscaleTaskProcessorTests : IDisposable
             _taskQueue,
             serviceProvider.GetRequiredService<IServiceScopeFactory>(),
             _mockOptions,
+            mockLogger,
             _mockPersistence
         );
     }

--- a/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskRegistryTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/BackgroundTaskQueue/TaskRegistryTests.cs
@@ -177,6 +177,7 @@ public class TaskRegistryTests
             taskQueue,
             scopeFactory,
             provider.GetRequiredService<IOptions<UpscalerConfig>>(),
+            Substitute.For<ILogger<DistributedUpscaleTaskProcessor>>(),
             persistence
         );
 

--- a/test/MangaIngestWithUpscaling.Tests/Services/LibraryIntegrity/LibraryIntegrityCheckerTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Services/LibraryIntegrity/LibraryIntegrityCheckerTests.cs
@@ -451,7 +451,7 @@ public class LibraryIntegrityCheckerTests : IDisposable
 
         int? total = null;
         int? current = null;
-        var reporter = new Progress<IntegrityProgress>(p =>
+        var reporter = new SynchronousProgress<IntegrityProgress>(p =>
         {
             if (p.Total.HasValue)
             {
@@ -2101,5 +2101,10 @@ public class LibraryIntegrityCheckerTests : IDisposable
                 .Options;
             return new ApplicationDbContext(options);
         }
+    }
+
+    private sealed class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
+    {
+        public void Report(T value) => handler(value);
     }
 }


### PR DESCRIPTION
## Summary
Hardens communication between remote task processors and the server when tasks are cancelled.

### Key Changes
1. **Remote Task Processor Cancellation Propagation ()**:
   -  now catches  from  RPC calls and cancels .
   - Linked cancellation tokens () bound to  pass to active ML operations (, ), aborting immediately upon cancellation.
   - Cancelled items in prefetch queue or prior to upload are skipped and cleaned up.
2. **Server-Side Guardrails ()**:
   - , , , and  reject operations if the target task status is .
3. **Task Processor Cleanup ()**:
   - Cleans up remote repair state and temp files when  is called.
4. **Unit Tests**:
   - Added  in .