### PR TITLE
fix: resolve .NET ThreadPool starvation and DB connection pool contention

### DIFF
--- a/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
+++ b/src/MangaIngestWithUpscaling.RemoteWorker/Background/RemoteTaskProcessor.cs
@@ -123,6 +123,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     {
                         resp = await client.RequestUpscaleTaskWithHintAsync(
                             new RequestTaskRequest { Prefetch = true },
+                            deadline: DateTime.UtcNow.AddSeconds(15),
                             cancellationToken: stoppingToken
                         );
                         serverAvailable = true;
@@ -202,6 +203,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                     var sw = Stopwatch.StartNew();
                     using AsyncServerStreamingCall<CbzFileChunk> stream = client.GetCbzFile(
                         new CbzToUpscaleRequest { TaskId = resp.TaskId, Prefetch = true },
+                        deadline: DateTime.UtcNow.AddMinutes(5),
                         cancellationToken: persistentKeepAliveCts.Token
                     );
                     string file = await FetchFile(
@@ -437,6 +439,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
 
                                     KeepAliveResponse? resp = await client.KeepAliveAsync(
                                         req,
+                                        deadline: DateTime.UtcNow.AddSeconds(10),
                                         cancellationToken: upscalesCts.Token
                                     );
                                     if (!resp.IsAlive)
@@ -709,6 +712,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                             TaskId = item.TaskId,
                             ErrorMessage = ex.Message,
                         },
+                        deadline: DateTime.UtcNow.AddSeconds(15),
                         cancellationToken: stoppingToken
                     );
                 }
@@ -893,6 +897,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
                             TaskId = item.TaskId,
                             ErrorMessage = ex.Message,
                         },
+                        deadline: DateTime.UtcNow.AddSeconds(15),
                         cancellationToken: stoppingToken
                     );
                 }
@@ -930,7 +935,10 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
     {
         await using FileStream fileStream = File.OpenRead(upscaledFile);
         AsyncDuplexStreamingCall<CbzFileChunk, UploadUpscaledCbzResponse>? uploadStream =
-            client.UploadUpscaledCbzFile(cancellationToken: stoppingToken);
+            client.UploadUpscaledCbzFile(
+                deadline: DateTime.UtcNow.AddMinutes(5),
+                cancellationToken: stoppingToken
+            );
         byte[] buffer = new byte[1024 * 1024];
         int bytesRead;
         int chunkNumber = 0;
@@ -988,6 +996,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
         {
             await client.UploadDetectionResultAsync(
                 new UploadDetectionResultRequest { TaskId = taskId, ResultJson = resultJson },
+                deadline: DateTime.UtcNow.AddSeconds(30),
                 cancellationToken: stoppingToken
             );
         }
@@ -1144,6 +1153,7 @@ public class RemoteTaskProcessor(IServiceScopeFactory serviceScopeFactory) : Bac
 
                         KeepAliveResponse? ka = await client.KeepAliveAsync(
                             requestFactory(id.Value),
+                            deadline: DateTime.UtcNow.AddSeconds(10),
                             cancellationToken: cts.Token
                         );
                         if (!ka.IsAlive)

--- a/src/MangaIngestWithUpscaling/Api/Auth/ApiKeyAuthenticationHandler.cs
+++ b/src/MangaIngestWithUpscaling/Api/Auth/ApiKeyAuthenticationHandler.cs
@@ -88,14 +88,15 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
         var principal = new ClaimsPrincipal(identity);
         var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
+        // Cache ticket for up to 1 minute to balance revocation latency with reducing DB queries
         var cacheOptions = new MemoryCacheEntryOptions
         {
-            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5),
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1),
         };
         if (apiKey.Expiration.HasValue)
         {
             var remainingTime = apiKey.Expiration.Value - currentUtc;
-            if (remainingTime < TimeSpan.FromMinutes(5))
+            if (remainingTime < TimeSpan.FromMinutes(1))
             {
                 cacheOptions.AbsoluteExpirationRelativeToNow =
                     remainingTime > TimeSpan.Zero ? remainingTime : TimeSpan.Zero;

--- a/src/MangaIngestWithUpscaling/Api/Auth/ApiKeyAuthenticationHandler.cs
+++ b/src/MangaIngestWithUpscaling/Api/Auth/ApiKeyAuthenticationHandler.cs
@@ -1,8 +1,9 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using System.Text.Encodings.Web;
 using MangaIngestWithUpscaling.Data;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
 namespace MangaIngestWithUpscaling.Api.Auth;
@@ -10,16 +11,19 @@ namespace MangaIngestWithUpscaling.Api.Auth;
 public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     private readonly ApplicationDbContext _context;
+    private readonly IMemoryCache _cache;
 
     public ApiKeyAuthenticationHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
         UrlEncoder encoder,
-        ApplicationDbContext context
+        ApplicationDbContext context,
+        IMemoryCache cache
     )
         : base(options, logger, encoder)
     {
         _context = context;
+        _cache = cache;
     }
 
     /// <summary>
@@ -43,6 +47,15 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
         var apiKeyValue = authHeaderValue.Substring("ApiKey ".Length).Trim();
         if (string.IsNullOrEmpty(apiKeyValue))
             return AuthenticateResult.Fail("Invalid API Key");
+
+        var cacheKey = $"ApiKeyAuth_{apiKeyValue}";
+        if (
+            _cache.TryGetValue(cacheKey, out AuthenticationTicket? cachedTicket)
+            && cachedTicket is not null
+        )
+        {
+            return AuthenticateResult.Success(cachedTicket);
+        }
 
         var apiKey = await _context
             .ApiKeys.Include(k => k.User)
@@ -74,6 +87,22 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var principal = new ClaimsPrincipal(identity);
         var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        var cacheOptions = new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5),
+        };
+        if (apiKey.Expiration.HasValue)
+        {
+            var remainingTime = apiKey.Expiration.Value - currentUtc;
+            if (remainingTime < TimeSpan.FromMinutes(5))
+            {
+                cacheOptions.AbsoluteExpirationRelativeToNow =
+                    remainingTime > TimeSpan.Zero ? remainingTime : TimeSpan.Zero;
+            }
+        }
+
+        _cache.Set(cacheKey, ticket, cacheOptions);
 
         return AuthenticateResult.Success(ticket);
     }

--- a/src/MangaIngestWithUpscaling/Api/Upscaling/UpscalingDistributionService.cs
+++ b/src/MangaIngestWithUpscaling/Api/Upscaling/UpscalingDistributionService.cs
@@ -316,7 +316,14 @@ public partial class UpscalingDistributionService(
             return;
         }
 
-        await using FileStream fileStream = File.OpenRead(filePath);
+        await using FileStream fileStream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            4096,
+            FileOptions.Asynchronous
+        );
         // Read the file in chunks of 1MB and stream it to the client
         var buffer = new byte[1024 * 1024];
         int bytesRead;
@@ -444,7 +451,14 @@ public partial class UpscalingDistributionService(
             return new CbzFileChunk();
         }
 
-        await using FileStream fileStream = File.OpenRead(filePath);
+        await using FileStream fileStream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            4096,
+            FileOptions.Asynchronous
+        );
         // Read the file in chunks of 1MB and stream it to the client
         var buffer = new byte[1024 * 1024];
         int bytesRead;

--- a/src/MangaIngestWithUpscaling/Api/Upscaling/UpscalingDistributionService.cs
+++ b/src/MangaIngestWithUpscaling/Api/Upscaling/UpscalingDistributionService.cs
@@ -321,7 +321,16 @@ public partial class UpscalingDistributionService(
         var buffer = new byte[1024 * 1024];
         int bytesRead;
         int chunkNumber = 0;
-        while ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0)
+        while (
+            (
+                bytesRead = await fileStream.ReadAsync(
+                    buffer,
+                    0,
+                    buffer.Length,
+                    context.CancellationToken
+                )
+            ) > 0
+        )
         {
             if (
                 context.CancellationToken.IsCancellationRequested
@@ -442,7 +451,16 @@ public partial class UpscalingDistributionService(
         int chunkNumber = 0;
         var offset = request.ChunkNumber * buffer.Length;
         fileStream.Seek(offset, SeekOrigin.Begin);
-        if ((bytesRead = fileStream.Read(buffer, 0, buffer.Length)) > 0)
+        if (
+            (
+                bytesRead = await fileStream.ReadAsync(
+                    buffer,
+                    0,
+                    buffer.Length,
+                    context.CancellationToken
+                )
+            ) > 0
+        )
         {
             context.Status = new Status(StatusCode.OK, "Chunk sent");
             return new CbzFileChunk

--- a/src/MangaIngestWithUpscaling/Program.cs
+++ b/src/MangaIngestWithUpscaling/Program.cs
@@ -196,6 +196,7 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 // Add services to the container.
 builder.Services.AddControllers();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+builder.Services.AddMemoryCache();
 
 builder.Services.AddGrpc();
 builder.Services.AddHealthChecks();

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskRegistry.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskRegistry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Reactive.Disposables;
 using AutoRegisterInject;
@@ -23,6 +24,9 @@ public class TaskRegistry : IHostedService, IDisposable
     private readonly TaskQueue _taskQueue;
     private readonly SourceCache<PersistedTask, int> _tasks = new(x => x.Id);
     private readonly UpscaleTaskProcessor _upscaleProcessor;
+    private readonly ConcurrentDictionary<int, PersistedTask> _pendingUpdates = new();
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _flushTask;
 
     public TaskRegistry(
         IServiceScopeFactory scopeFactory,
@@ -74,6 +78,8 @@ public class TaskRegistry : IHostedService, IDisposable
 
     public void Dispose()
     {
+        _cts.Cancel();
+        _cts.Dispose();
         _cleanups.Dispose();
         _tasks.Dispose();
     }
@@ -95,28 +101,84 @@ public class TaskRegistry : IHostedService, IDisposable
         _standardProcessor.StatusChanged += OnTaskChanged;
         _upscaleProcessor.StatusChanged += OnTaskChanged;
         _distributedUpscaleProcessor.StatusChanged += OnTaskChanged;
+
+        _flushTask = RunFlushLoopAsync(_cts.Token);
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
         _taskQueue.TaskEnqueuedOrChanged -= OnTaskChanged;
         _taskQueue.TaskRemoved -= OnTaskRemoved;
         _standardProcessor.StatusChanged -= OnTaskChanged;
         _upscaleProcessor.StatusChanged -= OnTaskChanged;
         _distributedUpscaleProcessor.StatusChanged -= OnTaskChanged;
-        return Task.CompletedTask;
+
+        await _cts.CancelAsync();
+        if (_flushTask != null)
+        {
+            try
+            {
+                await _flushTask;
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        FlushPendingUpdates();
     }
 
     private Task OnTaskChanged(PersistedTask task)
     {
-        _tasks.AddOrUpdate(CloneShallow(task));
+        _pendingUpdates[task.Id] = CloneShallow(task);
         return Task.CompletedTask;
     }
 
     private Task OnTaskRemoved(PersistedTask task)
     {
+        _pendingUpdates.TryRemove(task.Id, out _);
         _tasks.Remove(task.Id);
         return Task.CompletedTask;
+    }
+
+    private async Task RunFlushLoopAsync(CancellationToken cancellationToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(100));
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await timer.WaitForNextTickAsync(cancellationToken);
+                FlushPendingUpdates();
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                // Ignore errors to keep the debouncing flush loop active
+            }
+        }
+    }
+
+    private void FlushPendingUpdates()
+    {
+        if (_pendingUpdates.IsEmpty)
+            return;
+
+        var keys = _pendingUpdates.Keys.ToList();
+        var itemsToUpdate = new List<PersistedTask>();
+        foreach (var key in keys)
+        {
+            if (_pendingUpdates.TryRemove(key, out var item))
+            {
+                itemsToUpdate.Add(item);
+            }
+        }
+
+        if (itemsToUpdate.Count > 0)
+        {
+            _tasks.Edit(updater => updater.AddOrUpdate(itemsToUpdate));
+        }
     }
 
     private static PersistedTask CloneShallow(PersistedTask src)

--- a/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskRegistry.cs
+++ b/src/MangaIngestWithUpscaling/Services/BackgroundTaskQueue/TaskRegistry.cs
@@ -24,6 +24,7 @@ public class TaskRegistry : IHostedService, IDisposable
     private readonly TaskQueue _taskQueue;
     private readonly SourceCache<PersistedTask, int> _tasks = new(x => x.Id);
     private readonly UpscaleTaskProcessor _upscaleProcessor;
+    private readonly ILogger<TaskRegistry>? _logger;
     private readonly ConcurrentDictionary<int, PersistedTask> _pendingUpdates = new();
     private readonly CancellationTokenSource _cts = new();
     private Task? _flushTask;
@@ -33,7 +34,8 @@ public class TaskRegistry : IHostedService, IDisposable
         TaskQueue taskQueue,
         StandardTaskProcessor standardProcessor,
         UpscaleTaskProcessor upscalerProcessor,
-        DistributedUpscaleTaskProcessor distributedUpscaleProcessor
+        DistributedUpscaleTaskProcessor distributedUpscaleProcessor,
+        ILogger<TaskRegistry>? logger = null
     )
     {
         _scopeFactory = scopeFactory;
@@ -41,6 +43,7 @@ public class TaskRegistry : IHostedService, IDisposable
         _standardProcessor = standardProcessor;
         _upscaleProcessor = upscalerProcessor;
         _distributedUpscaleProcessor = distributedUpscaleProcessor;
+        _logger = logger;
 
         // Standard view: non-upscale tasks, sorted by status priority, then Order, then CreatedAt
         _tasks
@@ -153,9 +156,12 @@ public class TaskRegistry : IHostedService, IDisposable
             {
                 break;
             }
-            catch
+            catch (Exception ex)
             {
-                // Ignore errors to keep the debouncing flush loop active
+                _logger?.LogError(
+                    ex,
+                    "Error occurred while flushing pending task updates in TaskRegistry"
+                );
             }
         }
     }

--- a/test/MangaIngestWithUpscaling.Tests/Api/Auth/ApiKeyAuthenticationHandlerTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Api/Auth/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,94 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using MangaIngestWithUpscaling.Api.Auth;
+using MangaIngestWithUpscaling.Data;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace MangaIngestWithUpscaling.Tests.Api.Auth;
+
+public class ApiKeyAuthenticationHandlerTests
+{
+    private static ApplicationDbContext CreateInMemoryDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAuthenticateAsync_ValidApiKey_CachesTicketAndReusesOnSecondCall()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        using var context = CreateInMemoryDbContext(dbName);
+
+        var user = new ApplicationUser
+        {
+            Id = "user1",
+            UserName = "testuser",
+            Email = "test@example.com",
+        };
+        var apiKey = new ApiKey
+        {
+            Id = 1,
+            Key = "valid-api-key-123",
+            IsActive = true,
+            UserId = "user1",
+            User = user,
+        };
+        context.Users.Add(user);
+        context.ApiKeys.Add(apiKey);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var options = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        options.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
+
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+
+        var handler = new ApiKeyAuthenticationHandler(
+            options,
+            loggerFactory,
+            UrlEncoder.Default,
+            context,
+            memoryCache
+        );
+
+        var scheme = new AuthenticationScheme(
+            "ApiKey",
+            "ApiKey",
+            typeof(ApiKeyAuthenticationHandler)
+        );
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = "ApiKey valid-api-key-123";
+
+        await handler.InitializeAsync(scheme, httpContext);
+
+        // Act 1: First call -> populates cache
+        var result1 = await handler.AuthenticateAsync();
+
+        // Assert 1
+        Assert.True(result1.Succeeded);
+        Assert.Equal("user1", result1.Principal!.FindFirstValue(ClaimTypes.NameIdentifier));
+
+        // Delete key from DB to verify second call uses memory cache and does not fail or hit DB
+        context.ApiKeys.Remove(apiKey);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act 2: Second call -> cache hit
+        var result2 = await handler.AuthenticateAsync();
+
+        // Assert 2
+        Assert.True(result2.Succeeded);
+        Assert.Equal("user1", result2.Principal!.FindFirstValue(ClaimTypes.NameIdentifier));
+    }
+}

--- a/test/MangaIngestWithUpscaling.Tests/Api/Auth/ApiKeyAuthenticationHandlerTests.cs
+++ b/test/MangaIngestWithUpscaling.Tests/Api/Auth/ApiKeyAuthenticationHandlerTests.cs
@@ -84,8 +84,19 @@ public class ApiKeyAuthenticationHandlerTests
         context.ApiKeys.Remove(apiKey);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Act 2: Second call -> cache hit
-        var result2 = await handler.AuthenticateAsync();
+        // Act 2: Second call using a new handler and HttpContext to verify IMemoryCache across requests
+        var handler2 = new ApiKeyAuthenticationHandler(
+            options,
+            loggerFactory,
+            UrlEncoder.Default,
+            context,
+            memoryCache
+        );
+        var httpContext2 = new DefaultHttpContext();
+        httpContext2.Request.Headers["Authorization"] = "ApiKey valid-api-key-123";
+
+        await handler2.InitializeAsync(scheme, httpContext2);
+        var result2 = await handler2.AuthenticateAsync();
 
         // Assert 2
         Assert.True(result2.Succeeded);


### PR DESCRIPTION
## Summary of Fixes

This PR resolves issues leading to Kestrel/gRPC 504 Gateway Timeouts and Blazor UI freezes caused by .NET ThreadPool starvation and EF Core connection pool contention during remote upscaling workloads.

### Changes Made

1. **Async File I/O in `UpscalingDistributionService`**
   - Replaced synchronous `fileStream.Read` calls with `await fileStream.ReadAsync(...)` in `GetCbzFile` and `RequestCbzFileChunk` to keep ThreadPool worker threads unblocked during storage I/O.

2. **Client-Side gRPC Deadlines in `RemoteTaskProcessor`**
   - Added explicit deadlines (10–15s for control RPCs, 5m for stream transfers) across all client gRPC calls so stalled/hung calls abort quickly.

3. **In-Memory API Key Caching in `ApiKeyAuthenticationHandler`**
   - Registered `IMemoryCache` and cached valid `AuthenticationTicket` instances to eliminate the 2 DB queries per gRPC call. Added unit tests in `ApiKeyAuthenticationHandlerTests`.

4. **Debounced `TaskRegistry` Status Updates**
   - Introduced a 100ms debouncing flush loop in `TaskRegistry` to batch task status updates and avoid executing DynamicData full re-sort passes across thousands of items on every KeepAlive ping.

### Verification
- Full solution build (`dotnet build --no-restore MangaIngestWithUpscaling.sln /p:TreatWarningsAsErrors=true`) succeeded with **0 warnings** and **0 errors**.
- All unit tests passed (240 in main app, 4 in worker, 102 in shared library).
- Formatted via `dotnet csharpier`.